### PR TITLE
[add] encoding functions

### DIFF
--- a/modules/embedding/__init__.py
+++ b/modules/embedding/__init__.py
@@ -1,2 +1,19 @@
-def handle_embedding():
-    pass
+from .base import BaseEmbeddingBackend
+from .embedding_output import EmbeddingOutput
+
+from .scratch_config import ScratchEmbeddingConfig
+from .trainable_embedding import TrainableEmbeddingBackend
+
+from .bert_config import BertEmbeddingConfig
+from .bert_tokenizer import BertTokenizerWrapper
+from .bert_embedding import BertEmbeddingBackend
+
+__all__ = [
+    "BaseEmbeddingBackend",
+    "EmbeddingOutput",
+    "ScratchEmbeddingConfig",
+    "TrainableEmbeddingBackend",
+    "BertEmbeddingConfig",
+    "BertTokenizerWrapper",
+    "BertEmbeddingBackend",
+]

--- a/modules/embedding/base.py
+++ b/modules/embedding/base.py
@@ -1,0 +1,31 @@
+from abc import ABC, abstractmethod
+
+from .embedding_output import EmbeddingOutput
+
+
+class BaseEmbeddingBackend(ABC):
+    """Abstract base class for interchangeable embedding backends.
+
+    All embedding backends should return an :class:`EmbeddingOutput` so that
+    downstream models can remain agnostic to whether the source representation
+    came from a scratch-trained embedding layer or a pretrained transformer.
+    """
+
+    @abstractmethod
+    def get_output_dim(self) -> int:
+        """Return the dimensionality of the embedding output.
+
+        :returns: Hidden dimension size.
+        :rtype: int
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def freeze(self) -> None:
+        """Freeze trainable parameters of the backend."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def unfreeze(self) -> None:
+        """Unfreeze trainable parameters of the backend."""
+        raise NotImplementedError

--- a/modules/embedding/bert_config.py
+++ b/modules/embedding/bert_config.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class BertEmbeddingConfig:
+    """Configuration for a BERT-based embedding backend.
+
+    :param model_name: Hugging Face model identifier, such as
+        ``"bert-base-uncased"``.
+    :type model_name: str
+    :param max_length: Maximum sequence length for tokenizer output.
+    :type max_length: int
+    :param dropout: Dropout applied after transformer token embeddings.
+    :type dropout: float
+    :param pooling: Pooling strategy for sentence embedding. Supported values:
+        - ``"cls"``
+        - ``"mean"``
+    :type pooling: str
+    :param fine_tune: Whether transformer weights remain trainable.
+    :type fine_tune: bool
+    """
+
+    model_name: str = "bert-base-uncased"
+    max_length: int = 160
+    dropout: float = 0.1
+    pooling: str = "mean"
+    fine_tune: bool = True
+
+    def validate(self) -> None:
+        """Validate configuration values.
+
+        :raises ValueError: If any field is invalid.
+        """
+        if not self.model_name:
+            raise ValueError("model_name must be a non-empty string")
+        if self.max_length <= 0:
+            raise ValueError("max_length must be > 0")
+        if not (0.0 <= self.dropout < 1.0):
+            raise ValueError("dropout must be in the range [0.0, 1.0)")
+        if self.pooling not in {"cls", "mean"}:
+            raise ValueError("pooling must be either 'cls' or 'mean'")

--- a/modules/embedding/bert_embedding.py
+++ b/modules/embedding/bert_embedding.py
@@ -1,0 +1,115 @@
+import torch
+import torch.nn as nn
+from transformers import AutoModel
+
+from .base import BaseEmbeddingBackend
+from .bert_config import BertEmbeddingConfig
+from .embedding_output import EmbeddingOutput
+
+
+class BertEmbeddingBackend(nn.Module, BaseEmbeddingBackend):
+    """BERT-based contextual embedding backend.
+
+    This backend consumes already-tokenized transformer inputs such as
+    ``input_ids`` and ``attention_mask`` and returns contextual token
+    embeddings in the shared :class:`EmbeddingOutput` format.
+
+    The underlying transformer backbone is loaded using
+    ``AutoModel.from_pretrained(...)``.
+
+    :param config: BERT embedding configuration.
+    :type config: BertEmbeddingConfig
+    """
+
+    def __init__(self, config: BertEmbeddingConfig) -> None:
+        super().__init__()
+        config.validate()
+        self.config = config
+
+        self.model = AutoModel.from_pretrained(config.model_name)
+        self.dropout = nn.Dropout(config.dropout)
+
+        if not config.fine_tune:
+            self.freeze()
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        token_type_ids: torch.Tensor | None = None,
+    ) -> EmbeddingOutput:
+        """Run transformer encoding and return standardized output.
+
+        :param input_ids: Transformer token ids of shape
+            ``[batch_size, sequence_length]``.
+        :type input_ids: torch.Tensor
+        :param attention_mask: Transformer attention mask of shape
+            ``[batch_size, sequence_length]``.
+        :type attention_mask: torch.Tensor
+        :param token_type_ids: Optional segment ids for models that use them.
+        :type token_type_ids: torch.Tensor | None
+        :returns: Standardized embedding output.
+        :rtype: EmbeddingOutput
+        """
+        model_inputs = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+        }
+        if token_type_ids is not None:
+            model_inputs["token_type_ids"] = token_type_ids
+
+        outputs = self.model(**model_inputs)
+
+        # Base AutoModel outputs last_hidden_state for encoder models such as BERT
+        token_embeddings = outputs.last_hidden_state
+        token_embeddings = self.dropout(token_embeddings)
+
+        if self.config.pooling == "cls":
+            sentence_embedding = token_embeddings[:, 0, :]
+        else:
+            sentence_embedding = self._masked_mean_pool(
+                token_embeddings=token_embeddings,
+                attention_mask=attention_mask,
+            )
+
+        return EmbeddingOutput(
+            token_embeddings=token_embeddings,
+            attention_mask=attention_mask.long(),
+            sentence_embedding=sentence_embedding,
+        )
+
+    def _masked_mean_pool(
+        self,
+        token_embeddings: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute masked mean pooling over transformer token embeddings.
+
+        :param token_embeddings: Transformer hidden states of shape
+            ``[batch_size, sequence_length, hidden_dim]``.
+        :type token_embeddings: torch.Tensor
+        :param attention_mask: Attention mask of shape
+            ``[batch_size, sequence_length]``.
+        :type attention_mask: torch.Tensor
+        :returns: Mean-pooled sentence embeddings of shape
+            ``[batch_size, hidden_dim]``.
+        :rtype: torch.Tensor
+        """
+        mask = attention_mask.unsqueeze(-1).float()
+        summed = (token_embeddings * mask).sum(dim=1)
+        counts = mask.sum(dim=1).clamp(min=1.0)
+        return summed / counts
+
+    def get_output_dim(self) -> int:
+        """Return transformer hidden size."""
+        return int(self.model.config.hidden_size)
+
+    def freeze(self) -> None:
+        """Freeze transformer parameters."""
+        for param in self.model.parameters():
+            param.requires_grad = False
+
+    def unfreeze(self) -> None:
+        """Unfreeze transformer parameters."""
+        for param in self.model.parameters():
+            param.requires_grad = True

--- a/modules/embedding/bert_tokenizer.py
+++ b/modules/embedding/bert_tokenizer.py
@@ -1,0 +1,43 @@
+from typing import Sequence
+
+import torch
+from transformers import AutoTokenizer
+
+from .bert_config import BertEmbeddingConfig
+
+
+class BertTokenizerWrapper:
+    """Tokenizer wrapper for transformer-based embedding backends.
+
+    This class isolates Hugging Face tokenization from the rest of the pipeline.
+    It converts raw text strings into tensors suitable for
+    transformer models.
+
+    :param config: BERT embedding configuration.
+    :type config: BertEmbeddingConfig
+    """
+
+    def __init__(self, config: BertEmbeddingConfig) -> None:
+        config.validate()
+        self.config = config
+        self.tokenizer = AutoTokenizer.from_pretrained(config.model_name)
+
+    def encode_texts(self, texts: Sequence[str]) -> dict[str, torch.Tensor]:
+        """Tokenize a batch of texts for transformer input.
+
+        :param texts: Raw or lightly normalized text strings.
+        :type texts: Sequence[str]
+        :returns: Dictionary containing at least:
+            - ``input_ids``: ``[batch_size, sequence_length]``
+            - ``attention_mask``: ``[batch_size, sequence_length]``
+            and possibly other model-specific fields such as
+            ``token_type_ids``.
+        :rtype: dict[str, torch.Tensor]
+        """
+        return self.tokenizer(
+            list(texts),
+            padding=True,
+            truncation=True,
+            max_length=self.config.max_length,
+            return_tensors="pt",
+        )

--- a/modules/embedding/embedding_output.py
+++ b/modules/embedding/embedding_output.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass
+class EmbeddingOutput:
+    """Standardized output container for all embedding backends.
+
+    This dataclass provides a shared interface so downstream models can work
+    with either scratch embeddings or transformer-based embeddings without
+    changing their calling code.
+
+    :param token_embeddings: Token-level embeddings of shape
+        ``[batch_size, sequence_length, hidden_dim]``.
+    :type token_embeddings: torch.Tensor
+    :param attention_mask: Attention or validity mask of shape
+        ``[batch_size, sequence_length]`` where 1 marks valid tokens and
+        0 marks padding.
+    :type attention_mask: torch.Tensor
+    :param sentence_embedding: Optional pooled sequence representation of shape
+        ``[batch_size, hidden_dim]``.
+    :type sentence_embedding: torch.Tensor | None
+    """
+
+    token_embeddings: torch.Tensor
+    attention_mask: torch.Tensor
+    sentence_embedding: Optional[torch.Tensor] = None

--- a/modules/embedding/scratch_config.py
+++ b/modules/embedding/scratch_config.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ScratchEmbeddingConfig:
+    """Configuration for a scratch-trained token embedding backend.
+
+    :param vocab_size: Size of the vocabulary including special tokens.
+    :type vocab_size: int
+    :param embedding_dim: Dimensionality of each token embedding vector.
+    :type embedding_dim: int
+    :param pad_idx: Padding token index used by the vocabulary.
+    :type pad_idx: int
+    :param dropout: Dropout applied after embedding lookup.
+    :type dropout: float
+    """
+
+    vocab_size: int
+    embedding_dim: int
+    pad_idx: int
+    dropout: float = 0.0
+
+    def validate(self) -> None:
+        """Validate configuration values.
+
+        :raises ValueError: If any field is invalid.
+        """
+        if self.vocab_size <= 0:
+            raise ValueError("vocab_size must be > 0")
+        if self.embedding_dim <= 0:
+            raise ValueError("embedding_dim must be > 0")
+        if self.pad_idx < 0 or self.pad_idx >= self.vocab_size:
+            raise ValueError("pad_idx must be within [0, vocab_size)")
+        if not (0.0 <= self.dropout < 1.0):
+            raise ValueError("dropout must be in the range [0.0, 1.0)")

--- a/modules/embedding/trainable_embedding.py
+++ b/modules/embedding/trainable_embedding.py
@@ -1,0 +1,111 @@
+import torch
+import torch.nn as nn
+
+from .base import BaseEmbeddingBackend
+from .embedding_output import EmbeddingOutput
+from .scratch_config import ScratchEmbeddingConfig
+
+
+class TrainableEmbeddingBackend(nn.Module, BaseEmbeddingBackend):
+    """Scratch-trained token embedding backend based on ``torch.nn.Embedding``.
+
+    This backend consumes integer token-id tensors produced by encoding pipeline and returns token-level embeddings in the shared
+    :class:`EmbeddingOutput` format.
+
+    Input:
+        ``token_ids`` of shape ``[batch_size, sequence_length]``
+
+    Output:
+        ``EmbeddingOutput`` with:
+        - ``token_embeddings``: ``[batch_size, sequence_length, embedding_dim]``
+        - ``attention_mask``: ``[batch_size, sequence_length]``
+        - ``sentence_embedding``: masked mean-pooled representation
+          ``[batch_size, embedding_dim]``
+
+    :param config: Scratch embedding configuration.
+    :type config: ScratchEmbeddingConfig
+    """
+
+    def __init__(self, config: ScratchEmbeddingConfig) -> None:
+        super().__init__()
+        config.validate()
+        self.config = config
+
+        self.embedding = nn.Embedding(
+            num_embeddings=config.vocab_size,
+            embedding_dim=config.embedding_dim,
+            padding_idx=config.pad_idx,
+        )
+        self.dropout = nn.Dropout(config.dropout)
+
+        self._reset_parameters()
+
+    def _reset_parameters(self) -> None:
+        """Initialize embedding weights and zero out the padding row."""
+        nn.init.normal_(self.embedding.weight, mean=0.0, std=0.02)
+        with torch.no_grad():
+            self.embedding.weight[self.config.pad_idx].fill_(0.0)
+
+    def forward(self, token_ids: torch.Tensor) -> EmbeddingOutput:
+        """Embed a batch of token-id sequences.
+
+        :param token_ids: Tensor of token ids with shape
+            ``[batch_size, sequence_length]`` and dtype ``torch.long``.
+        :type token_ids: torch.Tensor
+        :returns: Standardized embedding output.
+        :rtype: EmbeddingOutput
+        """
+        if token_ids.dtype != torch.long:
+            raise TypeError(
+                f"TrainableEmbeddingBackend expects torch.long token ids, "
+                f"got {token_ids.dtype}."
+            )
+
+        token_embeddings = self.embedding(token_ids)
+        token_embeddings = self.dropout(token_embeddings)
+
+        attention_mask = (token_ids != self.config.pad_idx).long()
+        sentence_embedding = self._masked_mean_pool(
+            token_embeddings=token_embeddings,
+            attention_mask=attention_mask,
+        )
+
+        return EmbeddingOutput(
+            token_embeddings=token_embeddings,
+            attention_mask=attention_mask,
+            sentence_embedding=sentence_embedding,
+        )
+
+    def _masked_mean_pool(
+        self,
+        token_embeddings: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute masked mean pooling over token embeddings.
+
+        :param token_embeddings: Embedded tokens of shape
+            ``[batch_size, sequence_length, embedding_dim]``.
+        :type token_embeddings: torch.Tensor
+        :param attention_mask: Valid-token mask of shape
+            ``[batch_size, sequence_length]``.
+        :type attention_mask: torch.Tensor
+        :returns: Mean-pooled sequence embeddings of shape
+            ``[batch_size, embedding_dim]``.
+        :rtype: torch.Tensor
+        """
+        mask = attention_mask.unsqueeze(-1).float()
+        summed = (token_embeddings * mask).sum(dim=1)
+        counts = mask.sum(dim=1).clamp(min=1.0)
+        return summed / counts
+
+    def get_output_dim(self) -> int:
+        """Return the embedding hidden size."""
+        return self.config.embedding_dim
+
+    def freeze(self) -> None:
+        """Freeze embedding parameters."""
+        self.embedding.weight.requires_grad = False
+
+    def unfreeze(self) -> None:
+        """Unfreeze embedding parameters."""
+        self.embedding.weight.requires_grad = True

--- a/modules/encoding/__init__.py
+++ b/modules/encoding/__init__.py
@@ -1,2 +1,9 @@
-def handle_encoding():
-    pass
+from .vocab_encoder import VocabEncoder
+from .sequence_encoder import SequenceEncoder
+from .label_encoder import LabelEncoder
+
+__all__ = [
+    "VocabEncoder",
+    "SequenceEncoder",
+    "LabelEncoder",
+]

--- a/modules/encoding/label_encoder.py
+++ b/modules/encoding/label_encoder.py
@@ -1,0 +1,88 @@
+from typing import Iterable
+
+
+class LabelEncoder:
+    """Encode string class labels into integer ids and decode them back.
+
+    Labels are sorted alphabetically during fitting for reproducibility.
+
+    """
+
+    def __init__(self):
+        self.label_to_id: dict[str, int] = {}
+        self.id_to_label: dict[int, str] = {}
+        self._fitted = False
+
+    def fit(self, labels: Iterable[str]) -> None:
+        """Fit the encoder on a collection of labels.
+
+        :param labels: Iterable of class labels.
+        :type labels: Iterable[str]
+        """
+        unique_labels = sorted(set(labels))
+
+        self.label_to_id = {
+            label: idx for idx, label in enumerate(unique_labels)
+        }
+        self.id_to_label = {
+            idx: label for label, idx in self.label_to_id.items()
+        }
+        self._fitted = True
+
+    def encode(self, label: str) -> int:
+        """Encode a single label into its integer id.
+
+        :param label: Label string.
+        :type label: str
+        :returns: Encoded label id.
+        :rtype: int
+        """
+        self._check_is_fitted()
+        if label not in self.label_to_id:
+            raise ValueError(f"Unknown label: {label}")
+        return self.label_to_id[label]
+
+    def encode_many(self, labels: Iterable[str]) -> list[int]:
+        """Encode multiple labels into integer ids.
+
+        :param labels: Iterable of label strings.
+        :type labels: Iterable[str]
+        :returns: Encoded label ids.
+        :rtype: list[int]
+        """
+        self._check_is_fitted()
+        return [self.encode(label) for label in labels]
+
+    def decode(self, label_id: int) -> str:
+        """Decode a label id back to its string label.
+
+        :param label_id: Encoded label id.
+        :type label_id: int
+        :returns: Decoded label string.
+        :rtype: str
+        """
+        self._check_is_fitted()
+        if label_id not in self.id_to_label:
+            raise ValueError(f"Unknown label id: {label_id}")
+        return self.id_to_label[label_id]
+
+    def decode_many(self, label_ids: Iterable[int]) -> list[str]:
+        """Decode multiple label ids into string labels.
+
+        :param label_ids: Iterable of encoded label ids.
+        :type label_ids: Iterable[int]
+        :returns: Decoded label strings.
+        :rtype: list[str]
+        """
+        self._check_is_fitted()
+        return [self.decode(label_id) for label_id in label_ids]
+
+    @property
+    def num_classes(self) -> int:
+        """Return the number of fitted classes."""
+        self._check_is_fitted()
+        return len(self.label_to_id)
+
+    def _check_is_fitted(self) -> None:
+        if not self._fitted:
+            raise ValueError("LabelEncoder has not been fitted yet.")

--- a/modules/encoding/sequence_encoder.py
+++ b/modules/encoding/sequence_encoder.py
@@ -1,0 +1,116 @@
+from typing import Iterable
+
+from .vocab_encoder import VocabEncoder
+
+
+class SequenceEncoder:
+    """Encode token sequences into padded/truncated integer sequences.
+
+    Uses a fitted :class:`VocabEncoder` to convert tokens into ids, then applies
+    optional padding and truncation to a fixed maximum length.
+
+    :param vocab_encoder: Fitted vocabulary encoder.
+    :type vocab_encoder: VocabEncoder
+    :param max_length: Fixed output length for each sequence.
+    :type max_length: int
+    :param padding: Padding strategy. Supported values:
+        - ``"post"``: pad at the end
+        - ``"pre"``: pad at the beginning
+    :type padding: str
+    :param truncating: Truncation strategy. Supported values:
+        - ``"post"``: truncate from the end
+        - ``"pre"``: truncate from the beginning
+    :type truncating: str
+    """
+
+    def __init__(
+        self,
+        vocab_encoder: VocabEncoder,
+        max_length: int,
+        padding: str = "post",
+        truncating: str = "post",
+    ):
+        if max_length <= 0:
+            raise ValueError("max_length must be > 0")
+        if padding not in {"post", "pre"}:
+            raise ValueError("padding must be 'post' or 'pre'")
+        if truncating not in {"post", "pre"}:
+            raise ValueError("truncating must be 'post' or 'pre'")
+
+        self.vocab_encoder = vocab_encoder
+        self.max_length = max_length
+        self.padding = padding
+        self.truncating = truncating
+
+    def encode_sequence(self, tokens: list[str]) -> list[int]:
+        """Encode and pad/truncate a single token sequence.
+
+        :param tokens: Input token list.
+        :type tokens: list[str]
+        :returns: Fixed-length list of token ids.
+        :rtype: list[int]
+        """
+        token_ids = self.vocab_encoder.encode_tokens(tokens)
+        return self._pad_or_truncate(token_ids)
+
+    def encode_sequences(self, token_sequences: Iterable[list[str]]) -> list[list[int]]:
+        """Encode and pad/truncate multiple token sequences.
+
+        :param token_sequences: Iterable of token lists.
+        :type token_sequences: Iterable[list[str]]
+        :returns: List of fixed-length token-id sequences.
+        :rtype: list[list[int]]
+        """
+        return [self.encode_sequence(seq) for seq in token_sequences]
+
+    def build_attention_mask(self, encoded_sequence: list[int]) -> list[int]:
+        """Build an attention mask for a padded encoded sequence.
+
+        Non-padding ids are marked as 1, padding ids as 0.
+
+        :param encoded_sequence: Padded encoded sequence.
+        :type encoded_sequence: list[int]
+        :returns: Binary attention mask.
+        :rtype: list[int]
+        """
+        return [
+            0 if token_id == self.vocab_encoder.pad_id else 1
+            for token_id in encoded_sequence
+        ]
+
+    def build_attention_masks(
+        self,
+        encoded_sequences: Iterable[list[int]],
+    ) -> list[list[int]]:
+        """Build attention masks for multiple encoded sequences.
+
+        :param encoded_sequences: Iterable of padded encoded sequences.
+        :type encoded_sequences: Iterable[list[int]]
+        :returns: List of binary attention masks.
+        :rtype: list[list[int]]
+        """
+        return [self.build_attention_mask(seq) for seq in encoded_sequences]
+
+    def _pad_or_truncate(self, token_ids: list[int]) -> list[int]:
+        """Apply fixed-length padding/truncation to a token-id sequence.
+
+        :param token_ids: Variable-length token-id sequence.
+        :type token_ids: list[int]
+        :returns: Fixed-length token-id sequence.
+        :rtype: list[int]
+        """
+        if len(token_ids) > self.max_length:
+            if self.truncating == "post":
+                token_ids = token_ids[:self.max_length]
+            else:
+                token_ids = token_ids[-self.max_length:]
+
+        pad_needed = self.max_length - len(token_ids)
+        if pad_needed > 0:
+            pad_values = [self.vocab_encoder.pad_id] * pad_needed
+            if self.padding == "post":
+                token_ids = token_ids + pad_values
+            else:
+                token_ids = pad_values + token_ids
+
+        return token_ids

--- a/modules/encoding/vocab_encoder.py
+++ b/modules/encoding/vocab_encoder.py
@@ -1,0 +1,143 @@
+from collections import Counter
+from typing import Iterable
+
+
+class VocabEncoder:
+    """Build and manage a token vocabulary for sequence encoding.
+
+    The vocabulary is built from tokenized training data only. Two special
+    tokens are always included:
+
+    - ``<pad>`` at index 0
+    - ``<unk>`` at index 1
+
+    Tokens can be filtered by minimum frequency and optional maximum
+    vocabulary size.
+
+    :param min_freq: Minimum token frequency required to enter the vocabulary.
+        Defaults to 1.
+    :type min_freq: int
+    :param max_vocab_size: Maximum vocabulary size including special tokens.
+        If ``None``, all eligible tokens are kept. Defaults to ``None``.
+    :type max_vocab_size: int | None
+    """
+
+    PAD_TOKEN = "<pad>"
+    UNK_TOKEN = "<unk>"
+
+    def __init__(self, min_freq: int = 1, max_vocab_size: int | None = None):
+        if min_freq < 1:
+            raise ValueError("min_freq must be >= 1")
+
+        self.min_freq = min_freq
+        self.max_vocab_size = max_vocab_size
+
+        self.token_to_id: dict[str, int] = {
+            self.PAD_TOKEN: 0,
+            self.UNK_TOKEN: 1,
+        }
+        self.id_to_token: dict[int, str] = {
+            0: self.PAD_TOKEN,
+            1: self.UNK_TOKEN,
+        }
+        self._fitted = False
+
+    def fit(self, token_sequences: Iterable[list[str]]) -> None:
+        """Build the vocabulary from a collection of token sequences.
+
+        :param token_sequences: Iterable of token lists.
+        :type token_sequences: Iterable[list[str]]
+        """
+        counter = Counter()
+
+        for seq in token_sequences:
+            counter.update(seq)
+
+        valid_tokens = [
+            token for token, freq in counter.items()
+            if freq >= self.min_freq
+        ]
+
+        # Sort by descending frequency, then alphabetically for reproducibility
+        valid_tokens.sort(key=lambda tok: (-counter[tok], tok))
+
+        if self.max_vocab_size is not None:
+            remaining_slots = max(self.max_vocab_size - len(self.token_to_id), 0)
+            valid_tokens = valid_tokens[:remaining_slots]
+
+        next_id = len(self.token_to_id)
+        for token in valid_tokens:
+            if token not in self.token_to_id:
+                self.token_to_id[token] = next_id
+                self.id_to_token[next_id] = token
+                next_id += 1
+
+        self._fitted = True
+
+    def encode_token(self, token: str) -> int:
+        """Encode a single token into its integer id.
+
+        Unknown tokens are mapped to ``<unk>``.
+
+        :param token: Input token.
+        :type token: str
+        :returns: Integer token id.
+        :rtype: int
+        """
+        self._check_is_fitted()
+        return self.token_to_id.get(token, self.unk_id)
+
+    def decode_token(self, token_id: int) -> str:
+        """Decode a token id back to its token string.
+
+        Unknown ids are mapped to ``<unk>``.
+
+        :param token_id: Encoded token id.
+        :type token_id: int
+        :returns: Token string.
+        :rtype: str
+        """
+        self._check_is_fitted()
+        return self.id_to_token.get(token_id, self.UNK_TOKEN)
+
+    def encode_tokens(self, tokens: list[str]) -> list[int]:
+        """Encode a token list into a list of token ids.
+
+        :param tokens: Token list.
+        :type tokens: list[str]
+        :returns: Encoded token ids.
+        :rtype: list[int]
+        """
+        self._check_is_fitted()
+        return [self.encode_token(token) for token in tokens]
+
+    def decode_ids(self, token_ids: list[int]) -> list[str]:
+        """Decode a list of token ids back into token strings.
+
+        :param token_ids: List of token ids.
+        :type token_ids: list[int]
+        :returns: Decoded token strings.
+        :rtype: list[str]
+        """
+        self._check_is_fitted()
+        return [self.decode_token(token_id) for token_id in token_ids]
+
+    @property
+    def vocab_size(self) -> int:
+        """Return the number of tokens in the vocabulary."""
+        self._check_is_fitted()
+        return len(self.token_to_id)
+
+    @property
+    def pad_id(self) -> int:
+        """Return the padding token id."""
+        return self.token_to_id[self.PAD_TOKEN]
+
+    @property
+    def unk_id(self) -> int:
+        """Return the unknown token id."""
+        return self.token_to_id[self.UNK_TOKEN]
+
+    def _check_is_fitted(self) -> None:
+        if not self._fitted:
+            raise ValueError("VocabEncoder has not been fitted yet.")

--- a/tests/test_embedding_scratch.py
+++ b/tests/test_embedding_scratch.py
@@ -1,0 +1,146 @@
+"""
+Unit tests for the scratch embedding backend in modules/embedding.
+
+Run with (from the project root):
+    pytest tests/test_embedding_scratch.py -v
+"""
+
+import pytest
+import torch
+
+from modules.embedding import ScratchEmbeddingConfig, TrainableEmbeddingBackend
+
+
+# ── ScratchEmbeddingConfig ───────────────────────────────────────────────────
+
+class TestScratchEmbeddingConfig:
+    def test_valid_config_passes(self):
+        config = ScratchEmbeddingConfig(
+            vocab_size=100,
+            embedding_dim=32,
+            pad_idx=0,
+            dropout=0.1,
+        )
+        config.validate()  # should not raise
+
+    def test_invalid_vocab_size_raises(self):
+        config = ScratchEmbeddingConfig(
+            vocab_size=0,
+            embedding_dim=32,
+            pad_idx=0,
+            dropout=0.1,
+        )
+        with pytest.raises(ValueError):
+            config.validate()
+
+    def test_invalid_embedding_dim_raises(self):
+        config = ScratchEmbeddingConfig(
+            vocab_size=100,
+            embedding_dim=0,
+            pad_idx=0,
+            dropout=0.1,
+        )
+        with pytest.raises(ValueError):
+            config.validate()
+
+    def test_invalid_pad_idx_raises(self):
+        config = ScratchEmbeddingConfig(
+            vocab_size=100,
+            embedding_dim=32,
+            pad_idx=100,
+            dropout=0.1,
+        )
+        with pytest.raises(ValueError):
+            config.validate()
+
+    def test_invalid_dropout_raises(self):
+        config = ScratchEmbeddingConfig(
+            vocab_size=100,
+            embedding_dim=32,
+            pad_idx=0,
+            dropout=1.0,
+        )
+        with pytest.raises(ValueError):
+            config.validate()
+
+
+# ── TrainableEmbeddingBackend ────────────────────────────────────────────────
+
+class TestTrainableEmbeddingBackend:
+    @pytest.fixture
+    def config(self):
+        return ScratchEmbeddingConfig(
+            vocab_size=50,
+            embedding_dim=16,
+            pad_idx=0,
+            dropout=0.0,
+        )
+
+    @pytest.fixture
+    def backend(self, config):
+        return TrainableEmbeddingBackend(config)
+
+    @pytest.fixture
+    def token_ids(self):
+        return torch.tensor(
+            [
+                [2, 5, 7, 0, 0],
+                [3, 4, 8, 9, 0],
+            ],
+            dtype=torch.long,
+        )
+
+    def test_output_shapes(self, backend, token_ids):
+        output = backend(token_ids)
+
+        assert output.token_embeddings.shape == (2, 5, 16)
+        assert output.attention_mask.shape == (2, 5)
+        assert output.sentence_embedding.shape == (2, 16)
+
+    def test_attention_mask_respects_padding(self, backend, token_ids):
+        output = backend(token_ids)
+
+        expected = torch.tensor(
+            [
+                [1, 1, 1, 0, 0],
+                [1, 1, 1, 1, 0],
+            ],
+            dtype=torch.long,
+        )
+        assert torch.equal(output.attention_mask, expected)
+
+    def test_pad_row_is_zeroed_on_initialization(self, backend):
+        pad_vector = backend.embedding.weight[backend.config.pad_idx]
+        assert torch.allclose(pad_vector, torch.zeros_like(pad_vector))
+
+    def test_get_output_dim(self, backend):
+        assert backend.get_output_dim() == 16
+
+    def test_forward_requires_long_dtype(self, backend):
+        token_ids = torch.tensor([[1.0, 2.0, 0.0]], dtype=torch.float32)
+        with pytest.raises(TypeError):
+            backend(token_ids)
+
+    def test_sentence_embedding_is_masked_mean(self, backend):
+        # Make embeddings deterministic for easier testing
+        with torch.no_grad():
+            backend.embedding.weight.zero_()
+            backend.embedding.weight[2].fill_(2.0)
+            backend.embedding.weight[5].fill_(4.0)
+            backend.embedding.weight[7].fill_(6.0)
+
+        token_ids = torch.tensor([[2, 5, 7, 0]], dtype=torch.long)
+        output = backend(token_ids)
+
+        # Mean of [2, 4, 6] = 4 for every embedding dimension
+        expected = torch.full((1, 16), 4.0)
+        assert torch.allclose(output.sentence_embedding, expected)
+
+    def test_freeze_sets_requires_grad_false(self, backend):
+        backend.freeze()
+        assert backend.embedding.weight.requires_grad is False
+
+    def test_unfreeze_sets_requires_grad_true(self, backend):
+        backend.freeze()
+        backend.unfreeze()
+        assert backend.embedding.weight.requires_grad is True

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,0 +1,204 @@
+"""
+Unit tests for modules/encoding.
+
+Run with (from the project root):
+    pytest tests/test_encoding.py -v
+"""
+
+import pytest
+
+from modules.encoding import VocabEncoder, SequenceEncoder, LabelEncoder
+
+
+# ── VocabEncoder ─────────────────────────────────────────────────────────────
+
+class TestVocabEncoder:
+    @pytest.fixture
+    def token_sequences(self):
+        return [
+            ["worker", "fell", "from", "ladder"],
+            ["worker", "reported", "pain"],
+            ["vehicle", "hit", "worker"],
+        ]
+
+    @pytest.fixture
+    def vocab(self, token_sequences):
+        vocab = VocabEncoder(min_freq=1)
+        vocab.fit(token_sequences)
+        return vocab
+
+    def test_special_tokens_present(self, vocab):
+        assert vocab.token_to_id["<pad>"] == 0
+        assert vocab.token_to_id["<unk>"] == 1
+
+    def test_vocab_size_greater_than_special_tokens(self, vocab):
+        assert vocab.vocab_size > 2
+
+    def test_encode_known_token(self, vocab):
+        token_id = vocab.encode_token("worker")
+        assert isinstance(token_id, int)
+        assert token_id != vocab.unk_id
+
+    def test_encode_unknown_token_returns_unk(self, vocab):
+        token_id = vocab.encode_token("nonexistent_token")
+        assert token_id == vocab.unk_id
+
+    def test_encode_decode_roundtrip(self, vocab):
+        tokens = ["worker", "fell", "from", "ladder"]
+        ids = vocab.encode_tokens(tokens)
+        decoded = vocab.decode_ids(ids)
+        assert decoded == tokens
+
+    def test_decode_unknown_id_returns_unk_token(self, vocab):
+        decoded = vocab.decode_token(999999)
+        assert decoded == "<unk>"
+
+    def test_fit_with_min_freq_filters_rare_tokens(self, token_sequences):
+        vocab = VocabEncoder(min_freq=2)
+        vocab.fit(token_sequences)
+
+        # "worker" appears twice and should stay
+        assert vocab.encode_token("worker") != vocab.unk_id
+
+        # "ladder" appears once and should be filtered out
+        assert vocab.encode_token("ladder") == vocab.unk_id
+
+    def test_access_before_fit_raises(self):
+        vocab = VocabEncoder()
+        with pytest.raises(ValueError):
+            _ = vocab.vocab_size
+
+    def test_invalid_min_freq_raises(self):
+        with pytest.raises(ValueError):
+            VocabEncoder(min_freq=0)
+
+
+# ── SequenceEncoder ──────────────────────────────────────────────────────────
+
+class TestSequenceEncoder:
+    @pytest.fixture
+    def vocab(self):
+        token_sequences = [
+            ["worker", "fell", "from", "ladder"],
+            ["vehicle", "hit", "worker"],
+        ]
+        vocab = VocabEncoder(min_freq=1)
+        vocab.fit(token_sequences)
+        return vocab
+
+    def test_encode_sequence_pads_to_max_length(self, vocab):
+        encoder = SequenceEncoder(vocab_encoder=vocab, max_length=6)
+        encoded = encoder.encode_sequence(["worker", "fell"])
+
+        assert len(encoded) == 6
+        assert encoded[-1] == vocab.pad_id
+        assert encoded[-2] == vocab.pad_id
+
+    def test_encode_sequence_truncates_post(self, vocab):
+        encoder = SequenceEncoder(
+            vocab_encoder=vocab,
+            max_length=3,
+            truncating="post",
+        )
+        encoded = encoder.encode_sequence(["worker", "fell", "from", "ladder"])
+        decoded = vocab.decode_ids(encoded)
+
+        assert len(encoded) == 3
+        assert decoded == ["worker", "fell", "from"]
+
+    def test_encode_sequence_truncates_pre(self, vocab):
+        encoder = SequenceEncoder(
+            vocab_encoder=vocab,
+            max_length=3,
+            truncating="pre",
+        )
+        encoded = encoder.encode_sequence(["worker", "fell", "from", "ladder"])
+        decoded = vocab.decode_ids(encoded)
+
+        assert len(encoded) == 3
+        assert decoded == ["fell", "from", "ladder"]
+
+    def test_padding_pre(self, vocab):
+        encoder = SequenceEncoder(
+            vocab_encoder=vocab,
+            max_length=5,
+            padding="pre",
+        )
+        encoded = encoder.encode_sequence(["worker", "fell"])
+
+        assert len(encoded) == 5
+        assert encoded[0] == vocab.pad_id
+        assert encoded[1] == vocab.pad_id
+        assert encoded[2] == vocab.pad_id
+
+    def test_build_attention_mask_marks_non_pad_as_one(self, vocab):
+        encoder = SequenceEncoder(vocab_encoder=vocab, max_length=5)
+        encoded = encoder.encode_sequence(["worker", "fell"])
+        mask = encoder.build_attention_mask(encoded)
+
+        assert mask == [1, 1, 0, 0, 0]
+
+    def test_encode_sequences_batch(self, vocab):
+        encoder = SequenceEncoder(vocab_encoder=vocab, max_length=4)
+        sequences = [["worker", "fell"], ["vehicle", "hit", "worker"]]
+        encoded_batch = encoder.encode_sequences(sequences)
+
+        assert len(encoded_batch) == 2
+        assert all(len(seq) == 4 for seq in encoded_batch)
+
+    def test_invalid_max_length_raises(self, vocab):
+        with pytest.raises(ValueError):
+            SequenceEncoder(vocab_encoder=vocab, max_length=0)
+
+    def test_invalid_padding_raises(self, vocab):
+        with pytest.raises(ValueError):
+            SequenceEncoder(vocab_encoder=vocab, max_length=5, padding="middle")
+
+    def test_invalid_truncating_raises(self, vocab):
+        with pytest.raises(ValueError):
+            SequenceEncoder(vocab_encoder=vocab, max_length=5, truncating="middle")
+
+
+# ── LabelEncoder ─────────────────────────────────────────────────────────────
+
+class TestLabelEncoder:
+    @pytest.fixture
+    def labels(self):
+        return ["Vehicular", "Object", "Vehicular", "Other"]
+
+    @pytest.fixture
+    def encoder(self, labels):
+        encoder = LabelEncoder()
+        encoder.fit(labels)
+        return encoder
+
+    def test_num_classes(self, encoder):
+        assert encoder.num_classes == 3
+
+    def test_encode_known_label(self, encoder):
+        encoded = encoder.encode("Vehicular")
+        assert isinstance(encoded, int)
+
+    def test_encode_many(self, encoder):
+        encoded = encoder.encode_many(["Vehicular", "Object"])
+        assert len(encoded) == 2
+        assert all(isinstance(x, int) for x in encoded)
+
+    def test_decode_roundtrip(self, encoder):
+        label = "Object"
+        encoded = encoder.encode(label)
+        decoded = encoder.decode(encoded)
+        assert decoded == label
+
+    def test_unknown_label_raises(self, encoder):
+        with pytest.raises(ValueError):
+            encoder.encode("UnknownLabel")
+
+    def test_unknown_label_id_raises(self, encoder):
+        with pytest.raises(ValueError):
+            encoder.decode(999)
+
+    def test_access_before_fit_raises(self):
+        encoder = LabelEncoder()
+        with pytest.raises(ValueError):
+            _ = encoder.num_classes


### PR DESCRIPTION
#47 

modules/encoding/
    __init__.py
    vocab_encoder.py
    sequence_encoder.py
    label_encoder.py

Sanity checks
vocabulary fit works ✅
unknown token fallback works ✅
sequence encoding works ✅
padding works ✅
decoding works ✅
label encoding works ✅

Example: With respect to model1_train.csv, min_freq=2, max_length=160(95th percentile)

`
TOKENS:
['whilst', 'driving', 'back', 'to', 'camp', 'the', 'lv', 'minivan', 'has', 'overtaken', 'a', 'vehicle', 'and', 'road', 'train', 'without', 'call-up', 'in', 'dusty', 'poor', 'visibility', 'conditions', 'the', 'lead', 'vehicle', 'behind', 'the', 'road', 'train', 'had', 'called', 'up', 'and', 'prepared', 'to', 'pass', 'the', 'road', 'train', 'as', 'the', 'driver', 'looked', 'to', 'the', 'right', 'the', 'unannounced', 'mini', 'van', 'had', 'already', 'commenced', 'his', 'pass', 'approach', 'and', 'was', 'to', 'the', 'right', 'of', 'the', 'lead', 'vehicle', 'minivan', 'had', 'left', 'nlo', 'and', 'was', 'being', 'driven', 'back', 'to', 'tambrah', 'camp', 'post', 'shift', 'road', 'train', 'rt', 'and', 'lv', 'were', 'ahead', 'of', 'the', 'minivan', 'driving', 'to', 'conditions', 'due', 'to', 'excess', 'dust', 'lv', 'has', 'communicated', 'with', 'rt', 'for', 'permission', 'to', 'overtake', 'when', 'clear', 'but', 'minivan', 'had', 'already', 'commenced', 'an', 'overtake', 'of', 'both', 'vehicles', 'without', 'establishing', 'positive', 'communication', 'with', 'either', 'driver']

ENCODED:
[  53  299   34    3  225    2   96 1799   17 1812    7   89    4   91
  518  150 2015   12 2718 2253 2411  911    2  598   89  298    2   91
  518   22  138   30    4 1387    3  449    2   91  518   21    2  151
 1105    3    2   40    2    1 2895    1   22  737  226   19  449 1285
    4    5    3    2   40    6    2  598   89 1799   22   36  336    4
    5   87  586   34    3  778  225  721   42   91  518 3086    4   96
   27 1967    6    2 1799  299    3  911  169    3 2742  462   96   17
 2037   14 3086   16  763    3 1026   37  459  100 1799   22  737  226
   44 1026    6  199  688  150 2098  319  619   14 1187  151    0    0
    0    0    0    0    0    0    0    0    0    0    0    0    0    0
    0    0    0    0    0    0    0    0    0    0    0    0    0    0
    0    0    0    0    0    0]

DECODED (no pad):
['whilst', 'driving', 'back', 'to', 'camp', 'the', 'lv', 'minivan', 'has', 'overtaken', 'a', 'vehicle', 'and', 'road', 'train', 'without', 'call-up', 'in', 'dusty', 'poor', 'visibility', 'conditions', 'the', 'lead', 'vehicle', 'behind', 'the', 'road', 'train', 'had', 'called', 'up', 'and', 'prepared', 'to', 'pass', 'the', 'road', 'train', 'as', 'the', 'driver', 'looked', 'to', 'the', 'right', 'the', '<unk>', 'mini', '<unk>', 'had', 'already', 'commenced', 'his', 'pass', 'approach', 'and', 'was', 'to', 'the', 'right', 'of', 'the', 'lead', 'vehicle', 'minivan', 'had', 'left', 'nlo', 'and', 'was', 'being', 'driven', 'back', 'to', 'tambrah', 'camp', 'post', 'shift', 'road', 'train', 'rt', 'and', 'lv', 'were', 'ahead', 'of', 'the', 'minivan', 'driving', 'to', 'conditions', 'due', 'to', 'excess', 'dust', 'lv', 'has', 'communicated', 'with', 'rt', 'for', 'permission', 'to', 'overtake', 'when', 'clear', 'but', 'minivan', 'had', 'already', 'commenced', 'an', 'overtake', 'of', 'both', 'vehicles', 'without', 'establishing', 'positive', 'communication', 'with', 'either', 'driver']

LABEL:
Vehicular -> 17
`

