### PR TITLE
Feature/#64 evaluation metrics

### DIFF
--- a/modules/training_loop/metrics.py
+++ b/modules/training_loop/metrics.py
@@ -16,7 +16,8 @@ def _compute_classification_metrics(y_true, y_pred, num_classes=None):
         num_classes: The number of classes. Inferred from data if None.
 
     Returns:
-        metrics Dictionary containing accuracy, precision/recall/f1 macro and weighted.
+        metrics Dictionary containing accuracy, precision/recall/f1 macro and weighted,
+        f1 per class, and confusion matrix.
 
     Notes:
         Class labels must be integer-encoded from 0 to num_classes-1.
@@ -34,6 +35,8 @@ def _compute_classification_metrics(y_true, y_pred, num_classes=None):
             "precision_weighted": 0.0,
             "recall_weighted": 0.0,
             "f1_weighted": 0.0,
+            "f1_per_class": [],      # empty list when no samples
+            "confusion_matrix": [],  # empty list when no samples
         }
 
     if num_classes is None:
@@ -69,6 +72,8 @@ def _compute_classification_metrics(y_true, y_pred, num_classes=None):
         "precision_weighted": (precision_per_class * weights).sum().item(),
         "recall_weighted": (recall_per_class * weights).sum().item(),
         "f1_weighted": (f1_per_class * weights).sum().item(),
+        "f1_per_class": f1_per_class.tolist(),
+        "confusion_matrix": cm.long().tolist(),
     }
 
     return metrics

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -159,12 +159,18 @@ class TestComputeClassificationMetrics:
             "precision_weighted",
             "recall_weighted",
             "f1_weighted",
+            "f1_per_class",
+            "confusion_matrix",
         }
         assert set(metrics.keys()) == expected
 
     def test_empty_input_returns_zeros(self):
         metrics = _compute_classification_metrics(torch.tensor([]), torch.tensor([]))
-        assert all(v == 0.0 for v in metrics.values())
+        numeric_keys = ["accuracy", "precision_macro", "recall_macro", "f1_macro",
+                    "precision_weighted", "recall_weighted", "f1_weighted"]
+        assert all(metrics[k] == 0.0 for k in numeric_keys)
+        assert metrics["f1_per_class"] == []
+        assert metrics["confusion_matrix"] == []
 
     def test_infers_num_classes(self):
         y = torch.tensor([0, 1, 2])


### PR DESCRIPTION
Added f1_per_class and confusion_matrix to _compute_classification_metrics return value.

- Added "f1_per_class" and "confusion_matrix" to metrics dict return value
- Updated empty case to return [] for both new fields
- Updated docstring Returns section
closes #64 
