### PR TITLE
#41 class specific metrics

### DIFF
--- a/modules/training_loop/__init__.py
+++ b/modules/training_loop/__init__.py
@@ -67,10 +67,15 @@ def training(
     epochs=10,
     patience=3,
     num_classes=None,
+    class_dict={},
     clip_grad_max_norm=1.0,
     #
     best_metric="loss",  # must be in: "loss", "accuracy", "precision_macro", "recall_macro", "f1_macro", "precision_weighted", "recall_weighted", "f1_weighted"
     best_metric_mode=None,
+    #
+    threshold=0.80,
+    temperature=1.5,
+    use_temperature=True,
     #
     parameters={},
     device="cpu",
@@ -105,13 +110,18 @@ def training(
         valid_dl:  DataLoader for validation data.
         test_dl:   DataLoader for test data.
 
-        epochs:       Number of training epochs.
-        patience:     Early stopping patience in epochs.
-        num_classes:  Number of output classes.
+        epochs:              Number of training epochs.
+        patience:            Early stopping patience in epochs.
+        num_classes:         Number of output classes.
+        class_dict:          Dictionary mapping class indices to class names // i.e. class index -> class name
         clip_grad_max_norm:  Max norm for gradient clipping.
 
         best_metric:         Metric used to select the best model checkpoint.
         best_metric_mode:    Towards 'min' or 'max' // Inferred from best_metric if None.
+
+        threshold:        Confidence threshold for auto-classification.
+        temperature:      Temperature for scaling logits...if use_temperature is True.
+        use_temperature:  Whether to apply temperature scaling to logits.
 
         parameters:  The training parameters in a dictionary format.
         device:      Device string, e.g. 'cpu' or 'cuda'.
@@ -151,10 +161,15 @@ def training(
         epochs=epochs,
         patience=patience,
         num_classes=num_classes,
+        class_dict=class_dict,
         clip_grad_max_norm=clip_grad_max_norm,
         #
         best_metric=best_metric,
         best_metric_mode=best_metric_mode,
+        #
+        threshold=threshold,
+        temperature=temperature,
+        use_temperature=use_temperature,
         #
         parameters=parameters,
         device=device,

--- a/modules/training_loop/config.py
+++ b/modules/training_loop/config.py
@@ -34,15 +34,20 @@ def _build_train_config(
     epochs,
     patience,
     num_classes,
+    class_dict,
     clip_grad_max_norm,
     #
     best_metric,
     best_metric_mode,
     #
+    threshold,
+    temperature,
+    use_temperature,
+    #
     parameters,
     device,
     #
-    compute_train_metrics,
+    compute_train_metrics,      # unused currently
     save,
     parent_dir,
     run_name,
@@ -115,6 +120,7 @@ def _build_train_config(
         "epochs": epochs,
         "patience": patience,
         "num_classes": num_classes,
+        "class_dict": class_dict,
         "clip_grad_max_norm": clip_grad_max_norm,
         #
         "compute_train_metrics": compute_train_metrics,
@@ -125,6 +131,10 @@ def _build_train_config(
         #
         "best_metric": best_metric,
         "best_metric_mode": best_metric_mode,
+        #
+        "threshold": threshold,
+        "temperature": temperature,
+        "use_temperature": use_temperature,
         #
         "parameters": parameters,
         "device": device,

--- a/modules/training_loop/evaluate.py
+++ b/modules/training_loop/evaluate.py
@@ -2,11 +2,11 @@
 
 import json
 import torch
+import torch.nn.functional as F
 from pathlib import Path
 
 from .metrics import _compute_classification_metrics
 from .utility import _unpack_batch
-from modules.inference import run_inference
 
 FATAL_CLASSES = ["Single Fatality", "Multiple Fatality"]
 
@@ -24,8 +24,8 @@ def evaluate(config):
             - criterion: The loss function.
             - device: The device to run the evaluation on.
             - num_classes: The number of classes in the classification task.
-            - class_names: List of class name strings.
-            - save_dir: Directory where the model was saved (passed from RunSaver).
+            - class_dict: Dictionary mapping class indices to class names.
+            - save_dir: Directory where the model was saved .
             - threshold: Confidence threshold for auto-classification. Defaults to 0.80.
             - temperature: Temperature value for scaling logits. Defaults to 1.5.
             - use_temperature: Whether to use temperature scaling. Defaults to True.
@@ -40,62 +40,62 @@ def evaluate(config):
             - fatal_flag_count: number of fatal predictions flagged
             - fatal_flag_rate: proportion of fatal predictions flagged
     """
+    model = config["model"]
     criterion = config["criterion"]
-    class_names = config.get("class_names", [])
-    threshold = config.get("threshold", 0.80)
-    save_dir = config.get("save_dir", None)
 
-    inference_result = run_inference(config)
-    if inference_result is None:
-        return {}
+    model.eval()
 
-    all_preds = inference_result["all_preds"]
-    all_targets = inference_result["all_targets"]
-    all_probs = inference_result["all_probs"]
-    total_examples = inference_result["total_examples"]
+    total_loss, total_examples = 0.0, 0
+    all_preds, all_targets, all_probs = [], [], []
 
-    # Recompute loss over test set (run_inference doesn't track loss)
-    total_loss = 0.0
     with torch.no_grad():
         for batch in config["test_dl"]:
             logits, targets = _unpack_batch(batch, config)
             loss = criterion(logits, targets)
-            total_loss += loss.item() * targets.size(0)
+
+            if config["use_temperature"]:
+                probs = F.softmax(logits / config["temperature"], dim=1)
+            else:
+                probs = F.softmax(logits, dim=1)
+
+            preds = probs.argmax(dim=1)
+
+            batch_size = targets.size(0)
+            total_loss += loss.item() * batch_size
+            total_examples += batch_size
+
+            all_preds.append(preds.detach().cpu())
+            all_targets.append(targets.detach().cpu())
+            all_probs.append(probs.detach().cpu())
+
     avg_loss = total_loss / max(total_examples, 1)
+    all_preds = torch.cat(all_preds) if all_preds else torch.tensor([])
+    all_targets = torch.cat(all_targets) if all_targets else torch.tensor([])
+    all_probs = torch.cat(all_probs) if all_probs else torch.tensor([])
 
     # Compute base classification metrics from metrics.py
     metrics = _compute_classification_metrics(
         y_true=all_targets,
         y_pred=all_preds,
-        num_classes=config["num_classes"],
+        config=config,
     )
     metrics["loss"] = avg_loss
-
+    
     # Threshold analysis - auto classification rate
     max_probs = all_probs.max(dim=1).values
-    high_confidence = (max_probs > threshold).sum().item()
+    high_confidence = (max_probs > config["threshold"]).sum().item()
     metrics["auto_classification_rate"] = high_confidence / max(total_examples, 1)
     metrics["meets_requirement"] = metrics["auto_classification_rate"] >= 0.70
-    metrics["threshold_used"] = threshold
 
     # Fatal category flagging - 100% of fatal predictions must be flagged
-    if class_names:
+    if not config["energy_model"]:
         fatal_indices = [
-            class_names.index(c) for c in FATAL_CLASSES if c in class_names
+            idx for idx, name in config.get("class_dict", {}).items()
+            if name in FATAL_CLASSES
         ]
         if fatal_indices:
             fatal_mask = torch.isin(all_preds, torch.tensor(fatal_indices))
             metrics["fatal_flag_count"] = fatal_mask.sum().item()
             metrics["fatal_flag_rate"] = fatal_mask.sum().item() / max(total_examples, 1)
-
-    # Save evaluation results to save_dir
-    if save_dir is not None:
-        save_path = Path(save_dir) / "evaluation_metrics.json"
-        serialisable_metrics = {
-            k: v.tolist() if hasattr(v, "tolist") else v
-            for k, v in metrics.items()
-        }
-        with open(save_path, "w", encoding="utf-8") as f:
-            json.dump(serialisable_metrics, f, indent=2)
 
     return metrics

--- a/modules/training_loop/evaluate.py
+++ b/modules/training_loop/evaluate.py
@@ -40,9 +40,12 @@ def evaluate(config):
             - auto_classification_rate: proportion of predictions above threshold
             - meets_requirement: whether auto_classification_rate >= 0.70
             - threshold_used: the threshold value used
-            - fatal_flag_count: number of fatal predictions flagged (if energy_model and class_dict has fatal classes)
-            - fatal_flag_rate: proportion of fatal predictions flagged (if energy_model and class_dict has fatal classes)
+            - fatal_flag_count: number of fatal predictions flagged (if not energy_model and class_dict has fatal classes)
+            - fatal_flag_rate: proportion of fatal predictions flagged (if not energy_model and class_dict has fatal classes)
     """
+    if config["test_dl"] is None:
+        return {}
+
     model = config["model"]
     criterion = config["criterion"]
 
@@ -89,7 +92,7 @@ def evaluate(config):
     high_confidence = (max_probs > config["threshold"]).sum().item()
     metrics["auto_classification_rate"] = high_confidence / max(total_examples, 1)
     metrics["meets_requirement"] = metrics["auto_classification_rate"] >= 0.70
-    metrics["threshold_used"] = threshold
+    metrics["threshold_used"] = config["threshold"]
 
     # Fatal category flagging - 100% of fatal predictions must be flagged
     if not config["energy_model"]:

--- a/modules/training_loop/evaluate.py
+++ b/modules/training_loop/evaluate.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 from .metrics import _compute_classification_metrics
 from .utility import _unpack_batch
+from .run_saving import RunSaver
+from modules.inference import run_inference
 
 FATAL_CLASSES = ["Single Fatality", "Multiple Fatality"]
 
@@ -86,6 +88,7 @@ def evaluate(config):
     high_confidence = (max_probs > config["threshold"]).sum().item()
     metrics["auto_classification_rate"] = high_confidence / max(total_examples, 1)
     metrics["meets_requirement"] = metrics["auto_classification_rate"] >= 0.70
+    metrics["threshold_used"] = threshold
 
     # Fatal category flagging - 100% of fatal predictions must be flagged
     if not config["energy_model"]:

--- a/modules/training_loop/evaluate.py
+++ b/modules/training_loop/evaluate.py
@@ -39,8 +39,9 @@ def evaluate(config):
             - loss
             - auto_classification_rate: proportion of predictions above threshold
             - meets_requirement: whether auto_classification_rate >= 0.70
-            - fatal_flag_count: number of fatal predictions flagged
-            - fatal_flag_rate: proportion of fatal predictions flagged
+            - threshold_used: the threshold value used
+            - fatal_flag_count: number of fatal predictions flagged (if energy_model and class_dict has fatal classes)
+            - fatal_flag_rate: proportion of fatal predictions flagged (if energy_model and class_dict has fatal classes)
     """
     model = config["model"]
     criterion = config["criterion"]

--- a/modules/training_loop/metrics.py
+++ b/modules/training_loop/metrics.py
@@ -7,22 +7,31 @@ import torch.optim as optim
 
 # CLASSIFICATION METRICS COMPUTATION // Compute common classification metrics (accuracy, precision, recall, F1) from true and predicted labels
 # Pure PyTorch implementation to avoid adding a hard dependency on sklearn.
-def _compute_classification_metrics(y_true, y_pred, num_classes=None):
-    """Compute common classification metrics from true and predicted labels.
+def _compute_classification_metrics(
+    y_true,
+    y_pred,
+    config,
+):
+    """Compute classification metrics using pure PyTorch.
 
     Args:
-        y_true: Tensor of shape (num_samples,) containing true class labels.
-        y_pred: Tensor of shape (num_samples,) containing predicted class labels.
-        num_classes: The number of classes. Inferred from data if None.
+        y_true: Tensor of shape (N,)
+        y_pred: Tensor of shape (N,)
+        config (dict): A configuration dictionary containing the following keys:
+            - num_classes: optional manual class count (inferred from data if None)
+            - class_dict: dict mapping class index -> class name
 
     Returns:
-        metrics Dictionary containing accuracy, precision/recall/f1 macro and weighted,
-        f1 per class, and confusion matrix.
-
-    Notes:
-        Class labels must be integer-encoded from 0 to num_classes-1.
-        If y_true is empty, all metrics are returned as 0.0.
+        Dictionary containing:
+            - accuracy
+            - macro / weighted precision, recall, f1
+            - class-specific metrics
+            - confusion matrix
     """
+    # Notes:
+    #     Class labels must be integer-encoded from 0 to num_classes-1.
+    #     If y_true is empty, all metrics are returned as 0.0.
+
     y_true = torch.as_tensor(y_true, dtype=torch.long)
     y_pred = torch.as_tensor(y_pred, dtype=torch.long)
 
@@ -35,45 +44,69 @@ def _compute_classification_metrics(y_true, y_pred, num_classes=None):
             "precision_weighted": 0.0,
             "recall_weighted": 0.0,
             "f1_weighted": 0.0,
-            "f1_per_class": [],      # empty list when no samples
-            "confusion_matrix": [],  # empty list when no samples
+            "class_metrics": {},
+            "confusion_matrix": [],
         }
 
-    if num_classes is None:
-        num_classes = int(torch.max(torch.cat([y_true, y_pred])).item()) + 1
+    if config.get("num_classes") is None:
+        num_classes = max(
+            int(torch.max(y_true).item()),
+            int(torch.max(y_pred).item())
+        ) + 1
+    else:
+        num_classes = config["num_classes"]
 
-    cm = torch.zeros((num_classes, num_classes), dtype=torch.float32)
-    for t, p in zip(y_true, y_pred):
-        cm[t, p] += 1.0
+    # Fast confusion matrix construction
+    indices = y_true * num_classes + y_pred
+    cm = torch.bincount(
+        indices,
+        minlength=num_classes * num_classes
+    ).reshape(num_classes, num_classes).float()
 
     tp = torch.diag(cm)
-    support = cm.sum(dim=1)
-    predicted = cm.sum(dim=0)
+    support = cm.sum(dim=1)      # true count per class
+    predicted = cm.sum(dim=0)    # predicted count per class
 
     eps = 1e-12
-    precision_per_class = tp / (predicted + eps)
-    recall_per_class = tp / (support + eps)
-    f1_per_class = (
-        2
-        * precision_per_class
-        * recall_per_class
-        / (precision_per_class + recall_per_class + eps)
-    )
 
-    weights = support / (support.sum() + eps)
+    precision = tp / (predicted + eps)
+    recall = tp / (support + eps)
+    f1 = 2 * precision * recall / (precision + recall + eps)
 
-    accuracy = (tp.sum() / (cm.sum() + eps)).item()
+    weights = support / support.sum()
+
+    # Masks for proper macro averaging
+    precision_mask = predicted > 0
+    recall_mask = support > 0
+    f1_mask = support > 0
+
+    precision_macro = precision[precision_mask].mean().item()
+    recall_macro = recall[recall_mask].mean().item()
+    f1_macro = f1[f1_mask].mean().item()
 
     metrics = {
-        "accuracy": accuracy,
-        "precision_macro": precision_per_class.mean().item(),
-        "recall_macro": recall_per_class.mean().item(),
-        "f1_macro": f1_per_class.mean().item(),
-        "precision_weighted": (precision_per_class * weights).sum().item(),
-        "recall_weighted": (recall_per_class * weights).sum().item(),
-        "f1_weighted": (f1_per_class * weights).sum().item(),
-        "f1_per_class": f1_per_class.tolist(),
+        "accuracy": (tp.sum() / cm.sum()).item(),
+
+        "precision_macro": precision_macro,
+        "recall_macro": recall_macro,
+        "f1_macro": f1_macro,
+
+        "precision_weighted": (precision * weights).sum().item(),
+        "recall_weighted": (recall * weights).sum().item(),
+        "f1_weighted": (f1 * weights).sum().item(),
+
+        "class_metrics": {},
         "confusion_matrix": cm.long().tolist(),
     }
+
+    for class_idx in range(num_classes):
+        class_name = config["class_dict"].get(class_idx, f"class_{class_idx}")
+
+        metrics["class_metrics"][class_name] = {
+            "precision": precision[class_idx].item(),
+            "recall": recall[class_idx].item(),
+            "f1": f1[class_idx].item(),
+            "support": int(support[class_idx].item()),
+        }
 
     return metrics

--- a/modules/training_loop/one_epoch.py
+++ b/modules/training_loop/one_epoch.py
@@ -68,7 +68,7 @@ def train_one_epoch(config):
 
     # Compute classification metrics
     metrics = _compute_classification_metrics(
-        y_true=all_targets, y_pred=all_preds, num_classes=config["num_classes"]
+        y_true=all_targets, y_pred=all_preds, config=config
     )
     metrics["loss"] = avg_loss
     metrics["lr"] = _get_learning_rates(config)

--- a/modules/training_loop/run_saving.py
+++ b/modules/training_loop/run_saving.py
@@ -14,6 +14,8 @@ import math
 import torch
 from pathlib import Path
 import matplotlib.pyplot as plt
+import seaborn as sns
+import numpy as np
 
 from .utility import _serialise_value
 
@@ -28,7 +30,35 @@ class RunSaver:
     # HISTORY DICTIONARY // Create a new history dictionary with empty lists for each metric
     def _initialise_history(self):
         return {
-            "train": {
+            "training": {
+                "train": {
+                    "loss": [],
+                    "accuracy": [],
+                    "precision_macro": [],
+                    "recall_macro": [],
+                    "f1_macro": [],
+                    "precision_weighted": [],
+                    "recall_weighted": [],
+                    "f1_weighted": [],
+                    "class_metrics": [],
+                    "confusion_matrix": [],
+                    "lr": [],
+                },
+                "val": {
+                    "loss": [],
+                    "accuracy": [],
+                    "precision_macro": [],
+                    "recall_macro": [],
+                    "f1_macro": [],
+                    "precision_weighted": [],
+                    "recall_weighted": [],
+                    "f1_weighted": [],
+                    "class_metrics": [],
+                    "confusion_matrix": [],
+                },
+                "epoch_time_sec": [],
+            },
+            "test": {
                 "loss": [],
                 "accuracy": [],
                 "precision_macro": [],
@@ -37,19 +67,13 @@ class RunSaver:
                 "precision_weighted": [],
                 "recall_weighted": [],
                 "f1_weighted": [],
-                "lr": [],
+                "class_metrics": [],
+                "confusion_matrix": [],
+                "auto_classification_rate": [],
+                "fatal_flag_count": [],
+                "fatal_flag_rate": [],
+                "meets_requirement": [],
             },
-            "val": {
-                "loss": [],
-                "accuracy": [],
-                "precision_macro": [],
-                "recall_macro": [],
-                "f1_macro": [],
-                "precision_weighted": [],
-                "recall_weighted": [],
-                "f1_weighted": [],
-            },
-            "epoch_time_sec": [],
         }
 
     # CREATE DIRECTORY // Create a directory for saving run artifacts based on the current timestamp
@@ -62,9 +86,15 @@ class RunSaver:
         return save_dir
 
     # APPEND METRICS TO HISTORY // Append the metrics for the current epoch to the history dictionary
-    def append_metrics(self, section, metrics):
+    def append_metrics(self, section, metrics, training=True):
         """Append the metrics for the current epoch to the history dictionary."""
-        history_section = self.history[section]
+        # Specify whether to append to the 'training' or 'test' section of the history dictionary
+        if training:
+            history_section = self.history["training"][section]
+        else:
+            history_section = self.history[section]
+        
+        # Append each metric to the corresponding list in the history dictionary
         for key in history_section.keys():
             if key in metrics:
                 history_section[key].append(metrics[key])
@@ -87,6 +117,7 @@ class RunSaver:
                 "model",
                 "train_dl",
                 "valid_dl",
+                "test_dl",
                 "optimiser",
                 "scheduler",
                 "criterion",
@@ -116,6 +147,74 @@ class RunSaver:
 
         return str(model_path), str(summary_path)
 
+    # PLOT CONFUSION MATRIX // Plot a confusion matrix as a heatmap
+    def plot_confusion_matrix(self, cm, save_path, class_dict=None):
+        """Plot and save a confusion matrix as a heatmap.
+        
+        Args:
+            cm: Confusion matrix as a 2D list or numpy array.
+            save_path: Path to save the confusion matrix plot.
+            class_dict: Optional dictionary mapping class indices to class names.
+        """
+        cm = np.array(cm)
+        num_classes = cm.shape[0]
+        
+        # Create class labels
+        if class_dict:
+            labels = [class_dict.get(i, f"class_{i}") for i in range(num_classes)]
+        else:
+            labels = [f"class_{i}" for i in range(num_classes)]
+        
+        plt.figure(figsize=(10, 8))
+        sns.heatmap(
+            cm,
+            annot=True,
+            fmt="d",
+            cmap="Blues",
+            xticklabels=labels,
+            yticklabels=labels,
+            cbar_kws={"label": "Count"},
+        )
+        plt.xlabel("Predicted Label")
+        plt.ylabel("True Label")
+        plt.title("Confusion Matrix")
+        plt.tight_layout()
+        plt.savefig(save_path, dpi=100)
+        plt.close()
+
+    # PLOT METRICS // Generate and save plots for each metric in the history
+    def plot_base_metrics(self, metric, x_values, best_epoch, save_dir, save_name, training=True):
+        """Plot a single metric for training and validation over epochs."""
+        plt.figure()
+        if training:
+            plt.plot(x_values, self.history["training"]["train"][metric], label=f"Train {metric}")
+            if metric != "lr":  # Don't plot validation metrics for learning rate 
+                plt.plot(x_values, self.history["training"]["val"][metric], label=f"Val {metric}")
+        else:
+            plt.plot(x_values, self.history["test"][metric], label=f"Test {metric}")
+        plt.axvline(
+            x=best_epoch,
+            color="green",
+            linestyle="--",
+            linewidth=2,
+            label=f"Best epoch ({best_epoch})",
+        )
+        plt.xlabel("Epoch")
+        plt.ylabel(metric.capitalize())
+        plt.title(f"{metric.capitalize()} over Epochs")
+        plt.legend(loc="best")
+        plt.grid()
+        if y_axis_ranges.get(metric) is not None:
+            plt.ylim(*y_axis_ranges[metric])
+        plt.xlim(1, x_max)
+        if training:        
+            plot_path = Path(save_dir) / f"{save_name}_{metric}_plot.png"
+        else:
+            plot_path = Path(save_dir) / f"{save_name}_test_{metric}_plot.png"
+        plt.savefig(plot_path)
+        plt.close()
+
+
     # PLOT HISTORY // Generate and save plots for each metric in the history
     def plot_history(self, best_epoch, save_dir, save_name):
         """Generate and save per-metric and combined plots from training history."""
@@ -133,57 +232,82 @@ class RunSaver:
         }
 
         # Derive a shared x-axis max rounded up to the next multiple of 5
-        num_epochs = len(self.history["train"]["loss"])
+        num_epochs = len(self.history["training"]["train"]["loss"])
         x_max = ((num_epochs + 4) // 5) * 5 if num_epochs > 0 else 5
         x_values = list(range(1, num_epochs + 1))
 
-        # plot metrics
-        metrics = self.history["val"].keys()
-        for metric in metrics:
-            plt.figure()
-            plt.plot(x_values, self.history["train"][metric], label=f"Train {metric}")
-            plt.plot(x_values, self.history["val"][metric], label=f"Val {metric}")
-            plt.axvline(
-                x=best_epoch,
-                color="green",
-                linestyle="--",
-                linewidth=2,
-                label=f"Best epoch ({best_epoch})",
-            )
-            plt.xlabel("Epoch")
-            plt.ylabel(metric.capitalize())
-            plt.title(f"{metric.capitalize()} over Epochs")
-            plt.legend()
-            plt.grid()
-            if y_axis_ranges.get(metric) is not None:
-                plt.ylim(*y_axis_ranges[metric])
-            plt.xlim(1, x_max)
-            plot_path = Path(save_dir) / f"{save_name}_{metric}_plot.png"
-            plt.savefig(plot_path)
-            plt.close()
+
+        # plot each metric for train and val over epochs  
+        for metric in ["loss", "accuracy", "f1_macro", "precision_weighted", "f1_weighted"]:
+            self.plot_base_metrics(metric, x_values, best_epoch, save_dir, save_name, training=True)
+            self.plot_base_metrics(metric, x_values, best_epoch, save_dir, save_name, training=False)
+
 
         # plot learning rate if available
-        if self.history["train"]["lr"]:
-            plt.figure()
-            plt.plot(x_values, self.history["train"]["lr"], label="Train lr")
-            plt.axvline(
-                x=best_epoch,
-                color="green",
-                linestyle="--",
-                linewidth=2,
-                label=f"Best epoch ({best_epoch})",
-            )
-            plt.xlabel("Epoch")
-            plt.ylabel("Learning rate")
-            plt.title("Learning rate over Epochs")
-            plt.legend()
-            plt.grid()
-            if y_axis_ranges.get("lr") is not None:
-                plt.ylim(*y_axis_ranges["lr"])
-            plt.xlim(1, x_max)
-            plot_path = Path(save_dir) / f"{save_name}_lr_plot.png"
-            plt.savefig(plot_path)
-            plt.close()
+        if self.history["training"]["train"]["lr"]:
+            self.plot_base_metrics("lr", x_values, best_epoch, save_dir, save_name, training=True)
+
+
+        # Plot class-specific metrics if available
+        train_class_metrics = self.history["training"]["train"].get("class_metrics", [])
+        val_class_metrics = self.history["training"]["val"].get("class_metrics", [])
+        
+        if train_class_metrics and isinstance(train_class_metrics[0], dict):
+            # Extract class names from first epoch
+            class_names = list(train_class_metrics[0].keys())
+            
+            # For each metric (precision, recall, f1), create per-class plots
+            for metric in ["precision", "recall", "f1"]:
+                plt.figure(figsize=(12, 6))
+                
+                for class_name in class_names:
+                    # Extract metric values for this class across epochs
+                    train_values = [
+                        epoch_metrics.get(class_name, {}).get(metric, 0.0)
+                        for epoch_metrics in train_class_metrics
+                    ]
+                    val_values = [
+                        epoch_metrics.get(class_name, {}).get(metric, 0.0)
+                        for epoch_metrics in val_class_metrics
+                    ]
+                    
+                    plt.plot(x_values, train_values, label=f"Train {class_name}", marker="o", alpha=0.7)
+                    plt.plot(x_values, val_values, label=f"Val {class_name}", marker="s", linestyle="--", alpha=0.7)
+                
+                plt.axvline(
+                    x=best_epoch,
+                    color="red",
+                    linestyle="--",
+                    linewidth=2,
+                    label=f"Best epoch ({best_epoch})",
+                )
+                plt.xlabel("Epoch")
+                plt.ylabel(metric.capitalize())
+                plt.title(f"Class-wise {metric.capitalize()} over Epochs")
+                plt.legend(loc="best", fontsize=8)
+                plt.grid()
+                plt.ylim(0.0, 1.0)
+                plt.xlim(1, x_max)
+                plot_path = Path(save_dir) / f"{save_name}_class_{metric}_plot.png"
+                plt.savefig(plot_path, dpi=100, bbox_inches="tight")
+                plt.close()
+
+
+        # Get confusion matrix metric for best epoch validation and test
+        val_confusion_matrices = self.history["training"]["val"].get("confusion_matrix", [])
+        test_confusion_matrices = self.history["test"].get("confusion_matrix", [])
+
+        # Plot best epoch validation confusion matrix
+        if val_confusion_matrices and len(val_confusion_matrices) >= best_epoch - 1:
+            best_val_cm = val_confusion_matrices[best_epoch - 1]
+            val_cm_path = Path(save_dir) / f"{save_name}_val_confusion_matrix_epoch{best_epoch}.png"
+            self.plot_confusion_matrix(best_val_cm, val_cm_path)
+        # Plot test confusion matrix
+        if test_confusion_matrices:
+            test_cm = test_confusion_matrices[-1] if isinstance(test_confusion_matrices, list) else test_confusion_matrices
+            test_cm_path = Path(save_dir) / f"{save_name}_test_confusion_matrix.png"
+            self.plot_confusion_matrix(test_cm, test_cm_path)
+
 
         # Combined plot: accuracy, precision_macro, recall_macro, f1_macro
         plt.figure(figsize=(12, 8))
@@ -203,19 +327,19 @@ class RunSaver:
             "f1_macro": "#6c3483",  # dark purple
         }
 
-        combined_metrics = ["accuracy", "precision_macro", "recall_macro", "f1_macro"]
+        combined_metrics = ["loss", "accuracy", "precision_weighted", "recall_macro", "f1_macro"]
 
         for metric in combined_metrics:
             plt.plot(
                 x_values,
-                self.history["train"][metric],
+                self.history["training"]["train"][metric],
                 label=f"Train {metric}",
                 color=train_colors[metric],
                 linewidth=2,
             )
             plt.plot(
                 x_values,
-                self.history["val"][metric],
+                self.history["training"]["val"][metric],
                 label=f"Val {metric}",
                 color=val_colors[metric],
                 linewidth=2,
@@ -239,3 +363,5 @@ class RunSaver:
         plot_path = Path(save_dir) / f"{save_name}_combined_metrics_plot.png"
         plt.savefig(plot_path)
         plt.close()
+
+

--- a/modules/training_loop/run_saving.py
+++ b/modules/training_loop/run_saving.py
@@ -73,6 +73,7 @@ class RunSaver:
                 "fatal_flag_count": [],
                 "fatal_flag_rate": [],
                 "meets_requirement": [],
+                "threshold_used": [],
             },
         }
 

--- a/modules/training_loop/train_loop.py
+++ b/modules/training_loop/train_loop.py
@@ -13,6 +13,7 @@ from .one_epoch import train_one_epoch
 from .validation import validate
 from .run_saving import RunSaver
 from .utility import _safe_class_name, _serialise_value, _is_better
+from .evaluate import evaluate
 
 
 #  MAIN TRAINING LOOP // ensures all control variables are consistent // compatible with Dataloader-based pipelines
@@ -95,7 +96,12 @@ def train_model_loop(
 
     if best_model_state_dict is not None:
         config["model"].load_state_dict(best_model_state_dict)
+    
+    # Final evaluation on test set using the best model
+    test_metrics = evaluate(config)
+    run_saver.append_metrics("test", test_metrics, training=False)
 
+    # Prepare run_summary for saving
     run_summary = {
         "config": config,
         "history": run_saver.history,

--- a/modules/training_loop/validation.py
+++ b/modules/training_loop/validation.py
@@ -19,12 +19,10 @@ def validate(config):
             - criterion: The loss function for evaluation.
             - device: The device to run on (e.g., 'cpu' or 'cuda').
             - num_classes: Number of classes in the classification task.
-            - compute_val_metrics: Whether to compute detailed metrics
-            (precision, recall, F1) beyond loss and accuracy.
+            - class_dict: Dictionary mapping class indices to class names.
 
     Returns:
-        dict: Validation metrics including accuracy, precision, recall,
-            F1 macro, precision weighted, recall weighted, F1 weighted, and loss.
+        dict: Validation metrics from _compute_classification_metrics.
     """
     model = config["model"]
     criterion = config["criterion"]
@@ -54,7 +52,7 @@ def validate(config):
     metrics = _compute_classification_metrics(
         y_true=all_targets,
         y_pred=all_preds,
-        num_classes=config["num_classes"],
+        config=config,
     )
     metrics["loss"] = avg_loss
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,3 +5,5 @@ spacy
 torch
 transformers
 matplotlib
+seaborn
+numpy

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -348,14 +348,13 @@ class TestEvaluateThreshold:
 
 
 class TestEvaluateFatalFlagging:
-    def test_fatal_keys_present_with_class_dict(self):
-        model = _NoLengthModel(out=3)
+    def test_fatal_metrics_absent_for_energy_model(self):
+        model = _NoLengthModel()
         dl = _make_dataloader()
-        config = _base_config(model, dl=dl)
-        config["class_dict"] = {0: "Safe", 1: "Single Fatality", 2: "Multiple Fatality"}
+        config = _base_config(model, dl=dl, energy_model=True)
         metrics = evaluate(config)
-        assert "fatal_flag_count" in metrics
-        assert "fatal_flag_rate" in metrics
+        assert metrics.get("fatal_flag_count") is None
+        assert metrics.get("fatal_flag_rate") is None
 
     def test_fatal_flag_count_non_negative(self):
         model = _NoLengthModel(out=3)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -348,13 +348,13 @@ class TestEvaluateThreshold:
 
 
 class TestEvaluateFatalFlagging:
-    def test_fatal_keys_absent_without_class_dict(self):
+    def test_fatal_metrics_absent_for_energy_model(self):
         model = _NoLengthModel()
         dl = _make_dataloader()
-        config = _base_config(model, dl=dl)
+        config = _base_config(model, dl=dl, energy_model=True)
         metrics = evaluate(config)
-        assert "fatal_flag_count" not in metrics
-        assert "fatal_flag_rate" not in metrics
+        assert metrics.get("fatal_flag_count") is None
+        assert metrics.get("fatal_flag_rate") is None
 
     def test_fatal_keys_present_with_class_dict(self):
         model = _NoLengthModel(out=3)
@@ -368,7 +368,7 @@ class TestEvaluateFatalFlagging:
     def test_fatal_flag_count_non_negative(self):
         model = _NoLengthModel(out=3)
         dl = _make_dataloader()
-        config = _base_config(model, dl=dl)
+        config = _base_config(model, dl=dl, energy_model=False)
         config["class_dict"] = {0: "Safe", 1: "Single Fatality", 2: "Multiple Fatality"}
         metrics = evaluate(config)
         assert metrics["fatal_flag_count"] >= 0
@@ -376,7 +376,7 @@ class TestEvaluateFatalFlagging:
     def test_fatal_flag_rate_in_zero_one_range(self):
         model = _NoLengthModel(out=3)
         dl = _make_dataloader()
-        config = _base_config(model, dl=dl)
+        config = _base_config(model, dl=dl, energy_model=False)
         config["class_dict"] = {0: "Safe", 1: "Single Fatality", 2: "Multiple Fatality"}
         metrics = evaluate(config)
         assert 0.0 <= metrics["fatal_flag_rate"] <= 1.0
@@ -384,7 +384,7 @@ class TestEvaluateFatalFlagging:
     def test_fatal_flag_count_consistent_with_rate(self):
         model = _NoLengthModel(out=3)
         dl = _make_dataloader(n=BATCH_SIZE)
-        config = _base_config(model, dl=dl)
+        config = _base_config(model, dl=dl, energy_model=False)
         config["class_dict"] = {0: "Safe", 1: "Single Fatality", 2: "Multiple Fatality"}
         metrics = evaluate(config)
         expected_rate = metrics["fatal_flag_count"] / BATCH_SIZE

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -81,6 +81,7 @@ def _base_config(model, *, need_length=False, energy_model=True, dl=None):
         "energy_model": energy_model,
         "num_classes": NUM_CLASSES,
         "criterion": nn.CrossEntropyLoss(),
+        "use_temperature": False,
     }
     if dl is not None:
         cfg["test_dl"] = dl

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -343,7 +343,7 @@ class TestEvaluateThreshold:
 
 
 class TestEvaluateFatalFlagging:
-    def test_fatal_keys_absent_without_class_names(self):
+    def test_fatal_keys_absent_without_class_dict(self):
         model = _NoLengthModel()
         dl = _make_dataloader()
         config = _base_config(model, dl=dl)
@@ -351,11 +351,11 @@ class TestEvaluateFatalFlagging:
         assert "fatal_flag_count" not in metrics
         assert "fatal_flag_rate" not in metrics
 
-    def test_fatal_keys_present_with_class_names(self):
+    def test_fatal_keys_present_with_class_dict(self):
         model = _NoLengthModel(out=3)
         dl = _make_dataloader()
         config = _base_config(model, dl=dl)
-        config["class_names"] = ["Safe", "Single Fatality", "Multiple Fatality"]
+        config["class_dict"] = {0: "Safe", 1: "Single Fatality", 2: "Multiple Fatality"}
         metrics = evaluate(config)
         assert "fatal_flag_count" in metrics
         assert "fatal_flag_rate" in metrics
@@ -364,7 +364,7 @@ class TestEvaluateFatalFlagging:
         model = _NoLengthModel(out=3)
         dl = _make_dataloader()
         config = _base_config(model, dl=dl)
-        config["class_names"] = ["Safe", "Single Fatality", "Multiple Fatality"]
+        config["class_dict"] = {0: "Safe", 1: "Single Fatality", 2: "Multiple Fatality"}
         metrics = evaluate(config)
         assert metrics["fatal_flag_count"] >= 0
 
@@ -372,7 +372,7 @@ class TestEvaluateFatalFlagging:
         model = _NoLengthModel(out=3)
         dl = _make_dataloader()
         config = _base_config(model, dl=dl)
-        config["class_names"] = ["Safe", "Single Fatality", "Multiple Fatality"]
+        config["class_dict"] = {0: "Safe", 1: "Single Fatality", 2: "Multiple Fatality"}
         metrics = evaluate(config)
         assert 0.0 <= metrics["fatal_flag_rate"] <= 1.0
 
@@ -380,45 +380,15 @@ class TestEvaluateFatalFlagging:
         model = _NoLengthModel(out=3)
         dl = _make_dataloader(n=BATCH_SIZE)
         config = _base_config(model, dl=dl)
-        config["class_names"] = ["Safe", "Single Fatality", "Multiple Fatality"]
+        config["class_dict"] = {0: "Safe", 1: "Single Fatality", 2: "Multiple Fatality"}
         metrics = evaluate(config)
         expected_rate = metrics["fatal_flag_count"] / BATCH_SIZE
         assert metrics["fatal_flag_rate"] == pytest.approx(expected_rate, abs=1e-5)
 
-    def test_no_fatal_class_in_class_names_skips_flagging(self):
+    def test_no_fatal_class_in_class_dict_skips_flagging(self):
         model = _NoLengthModel(out=3)
         dl = _make_dataloader()
         config = _base_config(model, dl=dl)
-        config["class_names"] = ["Alpha", "Beta", "Gamma"]  # no fatal names
+        config["class_dict"] = {0: "Alpha", 1: "Beta", 2: "Gamma"}  # no fatal names
         metrics = evaluate(config)
         assert "fatal_flag_count" not in metrics
-
-
-class TestEvaluateSaveDir:
-    def test_saves_json_to_save_dir(self, tmp_path):
-        model = _NoLengthModel()
-        dl = _make_dataloader()
-        config = _base_config(model, dl=dl)
-        config["save_dir"] = str(tmp_path)
-        evaluate(config)
-        out_file = tmp_path / "evaluation_metrics.json"
-        assert out_file.exists()
-
-    def test_saved_json_contains_expected_keys(self, tmp_path):
-        model = _NoLengthModel()
-        dl = _make_dataloader()
-        config = _base_config(model, dl=dl)
-        config["save_dir"] = str(tmp_path)
-        evaluate(config)
-        with open(tmp_path / "evaluation_metrics.json") as f:
-            saved = json.load(f)
-        assert "accuracy" in saved
-        assert "loss" in saved
-        assert "auto_classification_rate" in saved
-
-    def test_no_save_without_save_dir(self, tmp_path):
-        model = _NoLengthModel()
-        dl = _make_dataloader()
-        config = _base_config(model, dl=dl)
-        evaluate(config)
-        assert not (tmp_path / "evaluation_metrics.json").exists()

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -263,7 +263,7 @@ class TestEvaluateBasic:
         expected = {
             "accuracy", "precision_macro", "recall_macro", "f1_macro",
             "precision_weighted", "recall_weighted", "f1_weighted",
-            "f1_per_class", "confusion_matrix",
+            "class_metrics", "confusion_matrix",
             "loss", "auto_classification_rate", "meets_requirement", "threshold_used",
         }
         assert expected.issubset(set(metrics.keys()))

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -84,6 +84,7 @@ def _base_config(model, *, need_length=False, energy_model=True, dl=None):
         "class_dict": {},
         "threshold": 0.80,
         "criterion": nn.CrossEntropyLoss(),
+        "temperature": 1.5,
         "use_temperature": False,
     }
     if dl is not None:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -348,14 +348,6 @@ class TestEvaluateThreshold:
 
 
 class TestEvaluateFatalFlagging:
-    def test_fatal_metrics_absent_for_energy_model(self):
-        model = _NoLengthModel()
-        dl = _make_dataloader()
-        config = _base_config(model, dl=dl, energy_model=True)
-        metrics = evaluate(config)
-        assert metrics.get("fatal_flag_count") is None
-        assert metrics.get("fatal_flag_rate") is None
-
     def test_fatal_keys_present_with_class_dict(self):
         model = _NoLengthModel(out=3)
         dl = _make_dataloader()

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -76,10 +76,13 @@ def _make_dataloader(n=BATCH_SIZE, seed=42):
 def _base_config(model, *, need_length=False, energy_model=True, dl=None):
     cfg = {
         "model": model,
+        "test_dl": None,  
         "device": torch.device("cpu"),
         "need_length": need_length,
         "energy_model": energy_model,
         "num_classes": NUM_CLASSES,
+        "class_dict": {},
+        "threshold": 0.80,
         "criterion": nn.CrossEntropyLoss(),
         "use_temperature": False,
     }

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -77,6 +77,14 @@ def _make_config(model, need_length=False, energy_model=False):
     }
 
 
+# A module-level fixture or variable
+@pytest.fixture
+def config():
+    return {
+        "num_classes": None,  # Will be set per test
+    }
+
+
 # ── _is_better ────────────────────────────────────────────────────────────────
 
 
@@ -137,21 +145,21 @@ class TestSerialiseValue:
 
 
 class TestComputeClassificationMetrics:
-    def test_perfect_predictions(self):
+    def test_perfect_predictions(self, config):
         y = torch.tensor([0, 1, 2, 0, 1, 2])
         config["num_classes"] = 3
         metrics = _compute_classification_metrics(y, y, config)
         assert metrics["accuracy"] == pytest.approx(1.0, abs=1e-5)
         assert metrics["f1_macro"] == pytest.approx(1.0, abs=1e-5)
 
-    def test_all_wrong_accuracy_zero(self):
+    def test_all_wrong_accuracy_zero(self, config):
         y_true = torch.tensor([0, 0, 0])
         y_pred = torch.tensor([1, 1, 1])
         config["num_classes"] = 2
         metrics = _compute_classification_metrics(y_true, y_pred, config)
         assert metrics["accuracy"] == pytest.approx(0.0, abs=1e-5)
 
-    def test_returns_expected_keys(self):
+    def test_returns_expected_keys(self, config):
         y = torch.tensor([0, 1])
         config["num_classes"] = None
         metrics = _compute_classification_metrics(y, y, config)
@@ -163,21 +171,21 @@ class TestComputeClassificationMetrics:
             "precision_weighted",
             "recall_weighted",
             "f1_weighted",
-            "f1_per_class",
+            "class_metrics",
             "confusion_matrix",
         }
         assert set(metrics.keys()) == expected
 
-    def test_empty_input_returns_zeros(self):
+    def test_empty_input_returns_zeros(self, config):
         config["num_classes"] = None
         metrics = _compute_classification_metrics(torch.tensor([]), torch.tensor([]), config)
         numeric_keys = ["accuracy", "precision_macro", "recall_macro", "f1_macro",
                     "precision_weighted", "recall_weighted", "f1_weighted"]
         assert all(metrics[k] == 0.0 for k in numeric_keys)
-        assert metrics["f1_per_class"] == []
+        assert metrics["class_metrics"] == {}
         assert metrics["confusion_matrix"] == []
 
-    def test_infers_num_classes(self):
+    def test_infers_num_classes(self, config):
         y = torch.tensor([0, 1, 2])
         config["num_classes"] = None
         metrics = _compute_classification_metrics(y, y, config)  # num_classes not passed

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -145,14 +145,15 @@ class TestSerialiseValue:
 
 
 
-
-class TestComputeClassificationMetrics:
-    config = {
-        "num_classes": None,
+@pytest.fixture
+def config():
+    return {
+        "num_classes": 3,
         "class_dict": {},
         "threshold": 0.80,
     }
-    
+
+class TestComputeClassificationMetrics:
     def test_perfect_predictions(self, config):
         y = torch.tensor([0, 1, 2, 0, 1, 2])
         config["num_classes"] = 3

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -139,19 +139,22 @@ class TestSerialiseValue:
 class TestComputeClassificationMetrics:
     def test_perfect_predictions(self):
         y = torch.tensor([0, 1, 2, 0, 1, 2])
-        metrics = _compute_classification_metrics(y, y, num_classes=3)
+        config["num_classes"] = 3
+        metrics = _compute_classification_metrics(y, y, config)
         assert metrics["accuracy"] == pytest.approx(1.0, abs=1e-5)
         assert metrics["f1_macro"] == pytest.approx(1.0, abs=1e-5)
 
     def test_all_wrong_accuracy_zero(self):
         y_true = torch.tensor([0, 0, 0])
         y_pred = torch.tensor([1, 1, 1])
-        metrics = _compute_classification_metrics(y_true, y_pred, num_classes=2)
+        config["num_classes"] = 2
+        metrics = _compute_classification_metrics(y_true, y_pred, config)
         assert metrics["accuracy"] == pytest.approx(0.0, abs=1e-5)
 
     def test_returns_expected_keys(self):
         y = torch.tensor([0, 1])
-        metrics = _compute_classification_metrics(y, y)
+        config["num_classes"] = None
+        metrics = _compute_classification_metrics(y, y, config)
         expected = {
             "accuracy",
             "precision_macro",
@@ -166,7 +169,8 @@ class TestComputeClassificationMetrics:
         assert set(metrics.keys()) == expected
 
     def test_empty_input_returns_zeros(self):
-        metrics = _compute_classification_metrics(torch.tensor([]), torch.tensor([]))
+        config["num_classes"] = None
+        metrics = _compute_classification_metrics(torch.tensor([]), torch.tensor([]), config)
         numeric_keys = ["accuracy", "precision_macro", "recall_macro", "f1_macro",
                     "precision_weighted", "recall_weighted", "f1_weighted"]
         assert all(metrics[k] == 0.0 for k in numeric_keys)
@@ -175,7 +179,8 @@ class TestComputeClassificationMetrics:
 
     def test_infers_num_classes(self):
         y = torch.tensor([0, 1, 2])
-        metrics = _compute_classification_metrics(y, y)  # num_classes not passed
+        config["num_classes"] = None
+        metrics = _compute_classification_metrics(y, y, config)  # num_classes not passed
         assert metrics["accuracy"] == pytest.approx(1.0, abs=1e-5)
 
 

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -144,7 +144,15 @@ class TestSerialiseValue:
 # ── _compute_classification_metrics ──────────────────────────────────────────
 
 
+
+
 class TestComputeClassificationMetrics:
+    config = {
+        "num_classes": None,
+        "class_dict": {},
+        "threshold": 0.80,
+    }
+    
     def test_perfect_predictions(self, config):
         y = torch.tensor([0, 1, 2, 0, 1, 2])
         config["num_classes"] = 3


### PR DESCRIPTION
Merge PR #96 first.

Training loop now calls `evaluate` function, the function itself has been fixed thoroughly and integrated within the pipeline (no more hallucinated arguments, cleaner saving etc.). Resolves issue #93 (finishes off issue #26)

Class specific metrics calculated in `_compute_classification_metrics` and saved for training, validation and testing steps. Resolves issue #41 

Expanded `RunSaver`, now tracks test set evaluation metrics and plots of class specific metrics along with confusion matrix for training, validation and testing steps. Concludes issue #24 