### PR TITLE
feat: add hyperparameter search leaderboard tracking (#117)

### DIFF
--- a/modules/leaderboard/__init__.py
+++ b/modules/leaderboard/__init__.py
@@ -1,6 +1,6 @@
 """Leaderboard module — tracks model runs in a persistent CSV."""
 
-from .logger import log_run
+from .logger import log_run, log_search_run
 from .runner import resolve_runner
 
-__all__ = ["log_run", "resolve_runner"]
+__all__ = ["log_run", "log_search_run", "resolve_runner"]

--- a/modules/leaderboard/logger.py
+++ b/modules/leaderboard/logger.py
@@ -132,6 +132,9 @@ def _build_row(run_summary: dict, config: dict, model_path: str, leaderboard_dir
         "req_fatal_accuracy_met": _last_test("req_fatal_accuracy_met"),
         "req_all_f1_targets_met": _last_test("req_all_f1_targets_met"),
         "per_class_requirements": json.dumps(_last_test("per_class_requirements")),
+        # --- Search parameters ---
+        "search_parameters": json.dumps(config.get("parameters", {})),
+        "is_hyperparameter_search": config.get("is_hyperparameter_search", False),
     }
 
 
@@ -171,7 +174,6 @@ def log_search_run(run_summary: dict, config: dict, model_path: str, leaderboard
     search_dir.mkdir(parents=True, exist_ok=True)
 
     row = _build_row(run_summary, config, model_path, leaderboard_dir)
-    row["search_parameters"] = json.dumps(config.get("parameters", {}))
 
     # 1. Append to all_searches.csv
     all_searches_path = search_dir / "all_searches.csv"

--- a/modules/leaderboard/logger.py
+++ b/modules/leaderboard/logger.py
@@ -171,6 +171,7 @@ def log_search_run(run_summary: dict, config: dict, model_path: str, leaderboard
     search_dir.mkdir(parents=True, exist_ok=True)
 
     row = _build_row(run_summary, config, model_path, leaderboard_dir)
+    row["search_parameters"] = json.dumps(config.get("parameters", {}))
 
     # 1. Append to all_searches.csv
     all_searches_path = search_dir / "all_searches.csv"

--- a/modules/leaderboard/logger.py
+++ b/modules/leaderboard/logger.py
@@ -151,3 +151,45 @@ def _get_git_commit_hash() -> str:
         return result.stdout.strip()
     except Exception:
         return ""
+    
+
+def log_search_run(run_summary: dict, config: dict, model_path: str, leaderboard_dir: str = "leaderboard") -> None:
+    """Log a hyperparameter search run to the search-specific leaderboard.
+
+    Records to two locations:
+    - leaderboard/search/all_searches.csv: all search runs combined
+    - leaderboard/search/search_TIMESTAMP.csv: this search session only
+
+    Args:
+        run_summary: Dictionary of run summary from train_loop.
+        config: Training configuration dictionary.
+        model_path: Path of the saved model.
+        leaderboard_dir: Base leaderboard directory. Defaults to 'leaderboard'.
+    """
+    leaderboard_dir = Path(leaderboard_dir)
+    search_dir = leaderboard_dir / "search"
+    search_dir.mkdir(parents=True, exist_ok=True)
+
+    row = _build_row(run_summary, config, model_path, leaderboard_dir)
+
+    # 1. Append to all_searches.csv
+    all_searches_path = search_dir / "all_searches.csv"
+    if all_searches_path.exists():
+        existing = pd.read_csv(all_searches_path)
+        updated = pd.concat([existing, pd.DataFrame([row])], ignore_index=True)
+    else:
+        updated = pd.DataFrame([row])
+    updated.to_csv(all_searches_path, index=False)
+
+    # 2. Append to search_TIMESTAMP.csv
+    timestamp = config.get("timestamp", datetime.now().strftime("%Y%m%d_%H%M%S"))
+    session_path = search_dir / f"search_{timestamp}.csv"
+    if session_path.exists():
+        existing = pd.read_csv(session_path)
+        updated = pd.concat([existing, pd.DataFrame([row])], ignore_index=True)
+    else:
+        updated = pd.DataFrame([row])
+    updated.to_csv(session_path, index=False)
+
+    print(f"Search leaderboard updated: {all_searches_path}")
+    print(f"Search session leaderboard updated: {session_path}")

--- a/modules/training_loop/train_loop.py
+++ b/modules/training_loop/train_loop.py
@@ -14,7 +14,7 @@ from .validation import validate
 from .run_saving import RunSaver
 from .utility import _safe_class_name, _serialise_value, _is_better
 from .evaluate import evaluate
-from ..leaderboard import log_run
+from ..leaderboard import log_run, log_search_run
 
 
 #  MAIN TRAINING LOOP // ensures all control variables are consistent // compatible with Dataloader-based pipelines
@@ -125,12 +125,20 @@ def train_model_loop(
         run_saver.plot_history(best_epoch, config["save_dir"], config["save_name"])
 
         if config.get("log_leaderboard", True):
-            log_run(
-                run_summary=run_summary,
-                config=config,
-                model_path=model_path,
-                leaderboard_dir=config.get("leaderboard_dir", "leaderboard"),
-            )
+            if config.get("is_hyperparameter_search", False):
+                log_search_run(
+                    run_summary=run_summary,
+                    config=config,
+                    model_path=model_path,
+                    leaderboard_dir=config.get("leaderboard_dir", "leaderboard"),
+                )
+            else:
+                log_run(
+                    run_summary=run_summary,
+                    config=config,
+                    model_path=model_path,
+                    leaderboard_dir=config.get("leaderboard_dir", "leaderboard"),
+                )
 
         if verbose:
             print(f"Run saved to: {config['save_dir']}")


### PR DESCRIPTION
Added hyperparameter search leaderboard tracking.

- Added log_search_run() in logger.py to record search runs separately
- Records to leaderboard/search/all_searches.csv (all searches combined)
- Records to leaderboard/search/search_TIMESTAMP.csv (per search session)
- Updated train_loop.py to call log_search_run() when is_hyperparameter_search=True
- Main leaderboard remains unaffected for normal training runs