### PR TITLE
hotfix for retraining

### DIFF
--- a/api/loader.py
+++ b/api/loader.py
@@ -170,11 +170,11 @@ def _build_model(
         dropout = float(artifacts.get("dropout", 0.2))
         num_classes = int(artifacts["label_enc"].num_classes)
 
-        tokeniser_name = artifacts.get("tokeniser_name")
+        tokenizer_name = artifacts.get("tokenizer_name")
 
         bert_cfg = BertEmbeddingConfig(
             model_name=model_name,
-            tokeniser_name=tokeniser_name,
+            tokenizer_name=tokenizer_name,
             max_length=max_length,
             dropout=0.1,
             pooling=pooling,

--- a/app/pages/retraining_page.py
+++ b/app/pages/retraining_page.py
@@ -555,11 +555,15 @@ if st.button("Retrain Model", type="primary"):
 
     cfg.update(extra_cfg)
 
-    import api
+    try:
+        import api
+        retrain = api.retrain
+    except Exception:
+        from api.retrain import retrain
 
     with st.spinner("Retraining in progress…"):
         try:
-            result = api.retrain(
+            result = retrain(
                 model_dir=str(selected_model_dir),
                 train_path=train_path,
                 valid_path=valid_path,

--- a/app/pages/retraining_page.py
+++ b/app/pages/retraining_page.py
@@ -555,11 +555,11 @@ if st.button("Retrain Model", type="primary"):
 
     cfg.update(extra_cfg)
 
-    from api import retrain
+    import api
 
     with st.spinner("Retraining in progress…"):
         try:
-            result = retrain(
+            result = api.retrain(
                 model_dir=str(selected_model_dir),
                 train_path=train_path,
                 valid_path=valid_path,

--- a/experiment_setup/bert_runner.py
+++ b/experiment_setup/bert_runner.py
@@ -20,7 +20,7 @@ def _label_encoder_from_class_dict(class_dict: dict) -> LabelEncoder:
 
 _BERT_DEFAULTS = {
     "model_type": "bert-base-uncased",                 # remove from config after refactor
-    "tokenizer_name": "bert-base-uncased-tokeniser",   # similarly, make passable to model/artifacts instead of setting in config
+    "tokenizer_name": None,
     "run_name": "bert_run",
     "fine_tune": False,
     "pooling": "mean",
@@ -108,7 +108,7 @@ def bert_train(
             "label_enc": _label_encoder_from_class_dict(dict(result["config"]["class_dict"])),
             "max_length": cfg["max_length"],
             "model_name": cfg["model_type"],
-            "tokenizer_name": cfg.get("tokenizer_name", cfg["model_type"]),
+            "tokenizer_name": cfg.get("tokenizer_name") or cfg["model_type"],
             "pooling": cfg["pooling"],
             "fine_tune": cfg["fine_tune"],
             "dropout": cfg["dropout"],


### PR DESCRIPTION
Several fixes for issues I faced with retraining:
- `from api import retraining` => did not work in my device, mine for some reason always try to import the submodule. Resorted to dictionary access with `import api` and `api.retrain()` which is more neutral
- BERT config uses `tokenizer` (US english), the retraining using `tokeniser` (EU english) results in `BertEmbeddingConfig.init() got an unexpected keyword argument 'tokeniser_name'` =>  Changed the spelling to use `tokenizer` instead.
- Exception: `bert-base-uncased-tokeniser is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models' If this is a private repository, make sure to pass a token having permission to this repo either by logging in with hf auth login or by passing token=<your_token>` => Caused by the original intent for `tokenizer_name` to be passed in by the caller so the model and tokenizer could differ (like custom BERT variant with a standard tokenizer). But no one ever wired up a real default, so the placeholder string silently corrupted every saved artifact. Since no one ever wired up that implementation, I'll just keep it as `None` by default. So if no `tokenizer_name` is passed, it uses `model_type` instead.

PS:
Note that I only test everything with default setting (leaving no custom setting) which I assume is a very `normal people` move. 